### PR TITLE
Add detailed spec references for core stages

### DIFF
--- a/spec/NANO_BANANA.md
+++ b/spec/NANO_BANANA.md
@@ -1,0 +1,44 @@
+# NANO BANANA Protocol
+
+> **NANO BANANA = Non-Negotiable Operational Baselines And Necessary Automation.**
+>
+> Codifies cross-stage guardrails implied by the master spec so every run is safe, observable, and recoverable.
+
+## Run Control
+- Pipeline executes sequential stages: scrape → process → audiences → creatives → images → qa → export.
+- Use idempotency key `{project_id}:{stage}:{run_tag}` for every task; reruns must reuse the same key to avoid duplicate writes.
+- Celery workers run with `concurrency=4`, `acks_late=true`, `prefetch=1`; apply backpressure when queue depth > 100.
+- Soft timeouts: scrape 900 s, process 300 s, gen 600 s, images 900 s.
+- On stage failure, persist diagnostic bundle and halt downstream work until operator reruns.
+
+## Budget Enforcement
+- Stage cost ceilings (cents): SCRAPE 50 · PROCESS 150 · AUDIENCE 300 · CREATIVE 200 · IMAGE 500.
+- Track cumulative spend per project; refuse new work when projected overrun > 5 % of budget.
+- Record every LLM/image call with prompt hash, token counts, provider, model, latency, and billable cost in `model_runs` table.
+
+## Security & Compliance
+- Authentication: API via `X-API-Key`; UI via JWT. Rotate keys regularly and log usage.
+- Crawling safety: restrict to submitted base domain/subdomains; block RFC1918, localhost, protocol upgrades that bypass HTTPS.
+- Storage: MinIO/S3 objects use signed URLs with short TTL; sanitize HTML/JS before persistence.
+- Privacy: drop PII from scrape payloads; respect robots.txt directives.
+
+## Observability
+- Metrics to emit:
+  - `andronoma_stage_latency_seconds{stage}`
+  - `andronoma_stage_cost_cents{stage}`
+  - `andronoma_tokens_total{provider,model,stage}`
+  - `andronoma_qa_failures_total{kind}`
+  - `andronoma_image_renders_total{status}`
+- Tracing: one OTEL trace per run; spans per stage with `project_id` attribute.
+- Alerts: trigger when SLO breach predicted (Run-All p95 ≥ 25 min or QA first-fix pass < 90 %).
+
+## Data Retention & Backups
+- S3 retention: raw 90 d, processed 180 d, outputs 365 d.
+- Database backups: nightly `pg_dump` (retain 7 days) + weekly full snapshot (retain 4 weeks).
+- Cleanup job purges orphaned S3 keys and expired signed URLs.
+
+## QA & Definition of Done
+- Spec-Kit check must pass before release.
+- All QA reports must pass with no unresolved blocker coverage gaps.
+- Deliverables: `audiences_master.csv` (≥100 rows, quotas satisfied), `scroll_stoppers.csv` (≥50 unique headlines with bucket coverage), rendered images (1080×1350 overlays), export bundle zipped and accessible via signed URL.
+- Document rerun steps and attach QA summaries in `/qa_reports/{project_id}`.

--- a/spec/OUTPUT_GENERATION.md
+++ b/spec/OUTPUT_GENERATION.md
@@ -1,0 +1,54 @@
+# Output Generation Requirements
+
+## Stage Sequence & Idempotency
+- Execute stages in order: **scrape → process → audiences → creatives → images → qa → export**.
+- Use idempotency key `{project_id}:{stage}:{run_tag}` to ensure repeatable runs. On QA failure, stop pipeline and surface remediation notes; do not silently regenerate downstream assets.
+
+## Audience Generation
+- Target 120 rows; QA trims to ≥ 100.
+- Quotas:
+  - Functional ≥ 12
+  - Emotional ≥ 12
+  - Situational ≥ 12
+  - Value/Price ≥ 10
+  - Behavioral ≥ 10
+  - Psychographic ≥ 10
+  - Professional ≥ 8
+  - Geo/Logistics ≥ 8
+  - Retargeting ≥ 10
+  - Edge/Contrarian ≥ 8
+  - Intersections ≥ 30
+  - Payment/Logistics ≥ 12
+  - Time-based ≥ 10
+- Seeds: 5–12 terms with ≥ 3 unique tokens per set.
+- Blocker binding: ≥ 1 per row, with ≥ 60 rows binding two blockers.
+- Retargeting states: PDP no ATC, ATC no checkout, checkout start no purchase, repeat 7d, viewed high-price, viewed small-only, bounced shipping/returns, engaged ads no visit, lapsed 30–90d, OOS viewers.
+- Deliverables:
+  - `outputs/audiences/audiences_master.csv`
+  - Dedupe report (list suppressed or merged rows)
+  - Gaps list (quota or persona deficits)
+
+## Creative (Scroll-Stopper) Generation
+- Produce ≥ 50 concepts.
+- Bucket coverage: Shock, Proof/Engineering, Emotional Story, Absurd/Surreal, Pure Aesthetic — each ≥ 10 concepts.
+- Blocker coverage: price, durability, scam/legitimacy, fit/dimension, delivery, style mismatch, returns friction, commitment fear, OOS — each addressed by ≥ 2 concepts.
+- Headlines: 3–10 words; no duplicates across entire set. Each concept includes visual directive, angle, audience fit, blocker binding, and proof cue.
+- Respect brand-safe tone: no discount or urgency hooks unless `PROMO_ALLOWED=on`.
+- Output `outputs/creatives/scroll_stoppers.csv` with schema `#,Headline,Visual,Angle,Blocker,Audience Fit`.
+
+## Image Stills
+- For every creative selected for imagery, render 1080×1350 (4:5) still with overlayed text.
+- Visual requirements: neutral interior scene, product hero focus, natural lighting, realistic shadows.
+- Overlay rules: headline 72–110 px, subcopy 36–48 px, CTA 40 px pill within safe area (72 px margins). Automatic light/dark contrast.
+- Naming: `/outputs/creatives/images/concept_##.jpg` matching creative index.
+
+## QA & Export
+- QA stage validates quotas, blocker coverage, naming consistency, CTA/value presence, duplicate guard, and image legibility.
+- Observability metrics: emit `andronoma_qa_failures_total{kind}` for any violation.
+- Export bundle contains `audiences_master.csv`, `scroll_stoppers.csv`, rendered images, QA reports, README mapping; optional Google Sheets mirror (tabs `audiences_master`, `scroll_stoppers`) and Meta CSV template.
+- Final bundle accessible via signed S3 URL with short TTL.
+
+## Budgets & Telemetry
+- Enforce per-stage budget ceilings (cents): SCRAPE 50 · PROCESS 150 · AUDIENCE 300 · CREATIVE 200 · IMAGE 500.
+- Record metrics per stage: `andronoma_stage_latency_seconds`, `andronoma_stage_cost_cents`, `andronoma_tokens_total`, `andronoma_image_renders_total{status}`.
+- SLO: full pipeline p95 < 25 minutes; QA first-fix pass rate > 90 %.

--- a/spec/PROCESSING_INSTRUCTIONS.md
+++ b/spec/PROCESSING_INSTRUCTIONS.md
@@ -1,0 +1,29 @@
+# Processing Stage Instructions
+
+## Stage Overview
+- Triggered after scrape completes successfully.
+- Consumes normalized research payloads to generate positioning intelligence for downstream generation.
+- Outputs saved under `/data/processed/{project_id}/processing.json` and summarized in QA reports.
+
+## Core Deliverables
+1. **Brand Position Analysis** – articulate category, promise, differentiators, proof pillars, and cost/value framing.
+2. **Motivation Map (F/E/A/S)** – map Functional, Emotional, Aspirational, Social motivators with supporting evidence.
+3. **Blockers Ranking** – rank objections by frequency × emotional weight; include triggers, personas affected, counter‑angles.
+4. **Market Summary** – competitor contrasts, cultural signals, whitespace opportunities, and macro trend notes.
+5. **Conversion Hypotheses** – value propositions + proof assets + CTA tone suggestions (from `conversion_hypotheses` module).
+6. **Ad Readiness Heuristics** – feed `ad_readiness` module with CTA/value/proof/legibility recommendations.
+7. **Brand Fit Score** – tone & aesthetic alignment output (0–100) from `brand_fit_score` module with rationale.
+
+## Craft Requirements
+- Every insight must be labeled **Direct** (explicitly observed) vs **Inferred** (derived). Ambiguous cases must surface ≥ 2 interpretations.
+- Cite the originating URL/hash for Direct signals; include reasoning chain for Inferred insights.
+- Highlight contrast: call out differentiators vs competitors, cultural signals, objection flips, audience gaps, barrier vs catalyst moments, whitespace.
+- Personas: cluster by intent/identity; specify segments benefiting from each motivation and the blockers they face.
+- Emotional frequency: quantify occurrence (High/Med/Low) to prioritize messaging.
+
+## Data Handling & QA
+- Persist intermediate embeddings/vectors needed by NLP modules (topic clustering, sentiment) to enable deterministic reruns.
+- Validate schema: ensure required keys exist; log missing data before proceeding.
+- Emit telemetry metrics `andronoma_stage_latency_seconds{stage="process"}` and `andronoma_stage_cost_cents` for cost tracking.
+- Budget guardrail: halt if estimated spend > 150 cents for the stage.
+- Soft timeout: 300 s with graceful cancellation and resumable checkpoints.

--- a/spec/SCRAPING_AND_RESEARCH.md
+++ b/spec/SCRAPING_AND_RESEARCH.md
@@ -1,0 +1,34 @@
+# Scraping & Research Requirements
+
+## Scope
+- Stage = **scrape** in orchestration (`scrape → process → audiences → creatives → images → qa → export`).
+- Input = project `{project_id, base_url, category, optional_keys}`.
+- Output feeds processing layer with raw product, brand, competitor, and SEO data.
+
+## Crawler Policy
+- Use **Playwright headless (stealth mode)** with session replay disabled.
+- Concurrency: ≤ 2 parallel Playwright contexts per domain.
+- Global request budget: ≤ 10 requests per second per domain.
+- Respect `robots.txt`; enforce 2 s crawl delay between hits on same host.
+- SSRF guard: allow only the submitted base domain + subdomains. Reject RFC1918, localhost, or redirected external hosts.
+
+## Coverage Goals
+- Product catalog coverage ≥ 95 % of SKUs accessible from navigation, sitemap, or collection pages.
+- Dimensional data (size, weight, length) captured for ≥ 90 % of products; normalize units → metric (cm, kg) and currency → minor units.
+- Reviews: capture content, rating, author (if public), timestamp. Deduplicate by review id/hash.
+- Brand voice: scrape About/Story/FAQ/Careers/Press pages + tone descriptors.
+- Visual descriptors: collect hero images, color palettes, textures.
+- Competitors: identify 3–7 relevant brands with price range, shipping model, standout differentiators.
+- SEO signals: capture H1/H2, meta title/description, alt text, structured keywords; note frequency weights.
+- Trend notes: log seasonal campaigns, collaborations, or timely hooks.
+
+## Data Handling
+- Cache responses in Redis for 24 h keyed by URL hash to enable idempotent reruns.
+- Persist normalized payload to `/data/raw/research/{project_id}/...` with checksum metadata.
+- Annotate each record with source URL, timestamp, and access method (direct crawl vs API).
+- Mask or drop PII (emails, phone numbers beyond public support lines).
+
+## Failure & Retry
+- Soft timeout for stage: 900 s; implement retry with exponential backoff (max 3) for transient HTTP errors.
+- On partial failure, flag gaps in QA notes rather than silently skipping.
+- Emit telemetry metrics: `andronoma_stage_latency_seconds{stage="scrape"}`, `andronoma_stage_cost_cents`, `andronoma_tokens_total` (when LLM enrichments occur).

--- a/spec/SCROLL_STOPPERS.md
+++ b/spec/SCROLL_STOPPERS.md
@@ -1,0 +1,37 @@
+# Scroll-Stoppers Playbook
+
+## Purpose
+Define requirements for the creative generation stage responsible for producing scroll-stopping ad concepts that sell through value, story, and proof without defaulting to discounts.
+
+## Volume & Coverage
+- Minimum concepts: **50** per run.
+- Bucket quotas (each ≥ 10):
+  1. Shock
+  2. Proof / Engineering
+  3. Emotional Story
+  4. Absurd / Surreal
+  5. Pure Aesthetic
+- Blocker coverage: address price, durability, scam/legitimacy, fit/dimension, delivery, style mismatch, returns friction, commitment fear, out-of-stock. Each blocker must be resolved by ≥ 2 concepts.
+- Audience alignment: each concept maps to at least one audience row and reflects its dominant motivation + blockers.
+
+## Concept Structure
+Every row in `scroll_stoppers.csv` must include:
+- `#` – stable identifier synced with pipeline ordering.
+- `Headline` – 3–10 words, unique across the run, brand-safe, and value-led. No fake urgency or discounting unless `PROMO_ALLOWED=on`.
+- `Visual` – concrete art direction describing subject, setting, composition, and styling cues.
+- `Angle` – strategic hook referencing motivation, proof, or cultural signal.
+- `Blocker` – the primary objection being flipped; if concept covers two blockers, note both.
+- `Audience Fit` – pointer to the matching audience segment identifier.
+
+## Craft Guardrails
+- Use concrete sensory language and proof cues (reviews, specs, certifications, origin stories) aligned with processing outputs.
+- Ensure CTA tone matches brand voice; escalate to QA if ad_readiness heuristics flag missing CTA/value/proof.
+- Run duplicate guard: reject identical or near-identical headlines, angles, or visual directions (cosine similarity threshold defined in `dup_guard`).
+- Ensure creative mix includes cultural signals and whitespace opportunities surfaced by processing stage.
+- Avoid claims that would trip policy (no medical, financial, or unverifiable superlatives) unless verified.
+
+## Delivery & QA Hooks
+- Save CSV to `outputs/creatives/scroll_stoppers.csv` with UTF-8 encoding.
+- Emit metadata manifest summarizing bucket counts, blocker coverage, duplicate guard stats.
+- Forward pass/fail flags to QA stage so violations increment `andronoma_qa_failures_total{kind="creative"}`.
+- Surface suggestions for imagery handoff (headline variant, overlay guidance, CTA tone) for each concept selected for rendering.


### PR DESCRIPTION
## Summary
- add dedicated spec documents covering scraping, processing, creative, and output requirements derived from the master spec
- codify cross-stage operational guardrails in the new NANO BANANA protocol reference
- ensure manifest-required files exist so Spec-Kit QA can validate documentation presence

## Testing
- python qa/check_manifest.py

------
https://chatgpt.com/codex/tasks/task_e_68e1e39d20e88324821efeb295c1a783