### PR TITLE
Add local infra scaffolding and pipeline documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,122 @@
+# Andronoma local development environment
+# Copy this file to .env and adjust the secrets for your setup.
+
+# ---------------------------------------------------------------------------- #
+# Core application configuration
+# ---------------------------------------------------------------------------- #
+ANDRONOMA_API_HOST=0.0.0.0
+ANDRONOMA_API_PORT=8000
+ANDRONOMA_LOG_LEVEL=info
+ANDRONOMA_JWT_SECRET=change-me
+ANDRONOMA_JWT_ALGORITHM=HS256
+ANDRONOMA_BUDGET_DEFAULT=1000
+
+# ---------------------------------------------------------------------------- #
+# Database (Postgres)
+# ---------------------------------------------------------------------------- #
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=andronoma
+POSTGRES_USER=andronoma
+POSTGRES_PASSWORD=andronoma
+ANDRONOMA_DATABASE_URL=postgresql+asyncpg://\${POSTGRES_USER}:\${POSTGRES_PASSWORD}@\${POSTGRES_HOST}:\${POSTGRES_PORT}/\${POSTGRES_DB}
+ANDRONOMA_SYNC_DATABASE_URL=postgresql+psycopg://\${POSTGRES_USER}:\${POSTGRES_PASSWORD}@\${POSTGRES_HOST}:\${POSTGRES_PORT}/\${POSTGRES_DB}
+
+# ---------------------------------------------------------------------------- #
+# Redis / Celery
+# ---------------------------------------------------------------------------- #
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_PASSWORD=
+REDIS_DB_CELERY=0
+REDIS_DB_RESULTS=1
+REDIS_DB_RATE_LIMITS=2
+ANDRONOMA_BROKER_URL=redis://:\${REDIS_PASSWORD}@\${REDIS_HOST}:\${REDIS_PORT}/\${REDIS_DB_CELERY}
+ANDRONOMA_RESULT_BACKEND=redis://:\${REDIS_PASSWORD}@\${REDIS_HOST}:\${REDIS_PORT}/\${REDIS_DB_RESULTS}
+CELERY_WORKER_CONCURRENCY=4
+CELERY_TASK_SOFT_TIME_LIMIT=600
+CELERY_TASK_TIME_LIMIT=900
+RATE_LIMIT_REQUESTS_PER_MINUTE=60
+RATE_LIMIT_BURST=120
+RATE_LIMIT_STORAGE_URL=redis://:\${REDIS_PASSWORD}@\${REDIS_HOST}:\${REDIS_PORT}/\${REDIS_DB_RATE_LIMITS}
+
+# ---------------------------------------------------------------------------- #
+# Object storage (MinIO / S3 compatible)
+# ---------------------------------------------------------------------------- #
+MINIO_ENDPOINT=minio:9000
+MINIO_ROOT_USER=andronoma
+MINIO_ROOT_PASSWORD=andronoma-secret
+ANDRONOMA_MINIO_ENDPOINT=minio:9000
+ANDRONOMA_MINIO_ACCESS_KEY=andronoma
+ANDRONOMA_MINIO_SECRET_KEY=andronoma-secret
+ANDRONOMA_MINIO_BUCKET=andronoma
+MINIO_USE_SSL=false
+MINIO_REGION=us-east-1
+
+# ---------------------------------------------------------------------------- #
+# LLM providers & generation services
+# ---------------------------------------------------------------------------- #
+OPENAI_API_KEY=
+OPENAI_ORG_ID=
+ANTHROPIC_API_KEY=
+REPLICATE_API_TOKEN=
+STABILITY_API_KEY=
+SERP_API_KEY=
+
+# ---------------------------------------------------------------------------- #
+# Optional commerce & export integrations
+# ---------------------------------------------------------------------------- #
+SHOPIFY_STORE_DOMAIN=
+SHOPIFY_ADMIN_TOKEN=
+GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON=./config/service-account.json
+GOOGLE_SHEETS_SPREADSHEET_ID=
+META_APP_ID=
+META_APP_SECRET=
+META_ACCESS_TOKEN=
+META_AD_ACCOUNT_ID=
+
+# ---------------------------------------------------------------------------- #
+# Feature and promo flags
+# ---------------------------------------------------------------------------- #
+FEATURE_SHOPIFY=false
+FEATURE_SHEETS=false
+FEATURE_META=false
+FEATURE_HEADLESS=true
+SPEC_ENFORCE_STRICT=false
+PROMO_ENABLE_ONBOARDING=true
+PROMO_DEFAULT_CREDIT_CENTS=500
+PROMO_CAMPAIGN_CODE=DEVLAUNCH
+PROMO_BANNER_TEXT=Welcome to the Andronoma beta!
+
+# ---------------------------------------------------------------------------- #
+# Telemetry / observability
+# ---------------------------------------------------------------------------- #
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+OTEL_SERVICE_NAME=andronoma
+PROMETHEUS_PUSHGATEWAY_URL=
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin
+
+# ---------------------------------------------------------------------------- #
+# Rate limit + security knobs
+# ---------------------------------------------------------------------------- #
+API_CORS_ALLOW_ORIGINS=http://localhost:5173
+API_ALLOWED_HOSTS=localhost,127.0.0.1
+API_KEY_HEADER=X-API-Key
+DEFAULT_API_KEY=
+
+# ---------------------------------------------------------------------------- #
+# MinIO buckets for outputs
+# ---------------------------------------------------------------------------- #
+MINIO_BUCKET_RAW=andronoma-raw
+MINIO_BUCKET_PROCESSED=andronoma-processed
+MINIO_BUCKET_OUTPUTS=andronoma-outputs
+
+# ---------------------------------------------------------------------------- #
+# Miscellaneous worker tuning
+# ---------------------------------------------------------------------------- #
+CELERY_QUEUE_DEFAULT=andronoma
+CELERY_QUEUE_PRIORITY=high
+RUN_SOFT_TIMEOUT_SECONDS=1500
+RUN_HARD_TIMEOUT_SECONDS=1800
+

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,376 @@
+openapi: 3.1.0
+info:
+  title: Andronoma Platform API
+  version: 0.1.0
+  description: |
+    Orchestration surface for the Andronoma campaign pipeline. All endpoints are
+    versionless for now and secured via bearer tokens that map to session
+    records. The service exposes helpers for discovering the pipeline ordering,
+    launching runs, inspecting telemetry, and streaming structured logs.
+servers:
+  - url: http://localhost:8000
+    description: Local development server
+security:
+  - bearerAuth: []
+tags:
+  - name: meta
+    description: Readiness and configuration helpers.
+  - name: auth
+    description: Authentication and session lifecycle.
+  - name: runs
+    description: Pipeline orchestration and telemetry APIs.
+  - name: logs
+    description: Server-sent event streams for run logs.
+paths:
+  /health:
+    get:
+      tags: [meta]
+      summary: Service health probe
+      description: Lightweight liveness endpoint for container orchestrators.
+      security: []
+      responses:
+        '200':
+          description: Service is ready to accept requests.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+  /settings:
+    get:
+      tags: [meta]
+      summary: Return the effective configuration
+      description: Echoes the merged settings object to assist the frontend and ops tooling.
+      security: []
+      responses:
+        '200':
+          description: Current configuration values.
+          content:
+            application/json:
+              schema:
+                type: object
+  /pipeline:
+    get:
+      tags: [meta]
+      summary: List the pipeline stages in execution order
+      description: Returns the canonical stage ordering used by workers and UI clients.
+      security: []
+      responses:
+        '200':
+          description: Ordered pipeline stages.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  stages:
+                    type: array
+                    items:
+                      type: string
+                    example:
+                      - scrape
+                      - process
+                      - audiences
+                      - creatives
+                      - images
+                      - qa
+                      - export
+  /auth/register:
+    post:
+      tags: [auth]
+      summary: Register a new user
+      description: Creates a user account and returns the persisted identity.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: User was created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '409':
+          description: Email is already registered.
+  /auth/login:
+    post:
+      tags: [auth]
+      summary: Exchange credentials for an access token
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Authenticated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '401':
+          description: Invalid credentials.
+  /auth/me:
+    get:
+      tags: [auth]
+      summary: Resolve the current authenticated user
+      responses:
+        '200':
+          description: Authenticated user profile.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '401':
+          description: Missing or invalid token.
+  /runs:
+    get:
+      tags: [runs]
+      summary: List runs owned by the authenticated user
+      responses:
+        '200':
+          description: Collection of pipeline runs.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunListResponse'
+    post:
+      tags: [runs]
+      summary: Create a new pipeline run
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunCreateRequest'
+      responses:
+        '201':
+          description: Run record created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunResponse'
+  /runs/{run_id}:
+    get:
+      tags: [runs]
+      summary: Retrieve details for a pipeline run
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: The requested run.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunResponse'
+        '404':
+          description: Run not found or forbidden.
+  /runs/{run_id}/start:
+    post:
+      tags: [runs]
+      summary: Transition a run into the active state and enqueue workers
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Run state after attempting to start.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunResponse'
+        '400':
+          description: Run is already active.
+        '403':
+          description: Forbidden for current user.
+        '404':
+          description: Run not found.
+  /runs/{run_id}/logs/stream:
+    get:
+      tags: [logs]
+      summary: Stream run logs in real time
+      description: Emits server-sent events where each event payload is JSON containing the log metadata.
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Event stream of log entries.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+      x-streaming: true
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: UUID
+  schemas:
+    LoginRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+          example: founder@example.com
+        password:
+          type: string
+          format: password
+          example: changeme123
+    LoginResponse:
+      type: object
+      required: [access_token, token_type]
+      properties:
+        access_token:
+          type: string
+          description: Session token to use in the Authorization header.
+        token_type:
+          type: string
+          example: bearer
+    UserResponse:
+      type: object
+      required: [id, email]
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+          format: email
+    PipelineConfig:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          example: Summer launch sprint
+        objectives:
+          type: array
+          items:
+            type: string
+          example:
+            - Validate positioning against core personas
+            - Launch creative exploration sprint
+        target_markets:
+          type: array
+          items:
+            type: string
+          example:
+            - US
+            - CA
+        metadata:
+          type: object
+          additionalProperties: {}
+    RunCreateRequest:
+      type: object
+      required: [config]
+      properties:
+        config:
+          $ref: '#/components/schemas/PipelineConfig'
+        budgets:
+          type: object
+          additionalProperties:
+            type: number
+            format: float
+    RunListResponse:
+      type: object
+      required: [runs]
+      properties:
+        runs:
+          type: array
+          items:
+            $ref: '#/components/schemas/RunResponse'
+    RunResponse:
+      type: object
+      required:
+        - id
+        - status
+        - input_payload
+        - budgets
+        - telemetry
+        - created_at
+        - updated_at
+        - stages
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/RunStatus'
+        input_payload:
+          type: object
+          additionalProperties: {}
+        budgets:
+          type: object
+          additionalProperties:
+            type: number
+        telemetry:
+          type: object
+          additionalProperties: {}
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        stages:
+          type: array
+          items:
+            $ref: '#/components/schemas/StageTelemetry'
+    StageTelemetry:
+      type: object
+      required:
+        - name
+        - status
+        - telemetry
+        - notes
+      properties:
+        name:
+          type: string
+        status:
+          $ref: '#/components/schemas/StageStatus'
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+        finished_at:
+          type: string
+          format: date-time
+          nullable: true
+        telemetry:
+          type: object
+          additionalProperties: {}
+        notes:
+          type: string
+          example: Awaiting QA signal
+    RunStatus:
+      type: string
+      enum: [pending, running, completed, failed, cancelled]
+    StageStatus:
+      type: string
+      enum: [pending, running, completed, failed, skipped]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,184 @@
+version: '3.9'
+
+services:
+  api:
+    image: python:3.11-slim
+    container_name: andronoma-api
+    working_dir: /app
+    volumes:
+      - ./:/app
+    command:
+      - bash
+      - -c
+      - >-
+        pip install --no-cache-dir -r requirements.txt &&
+        uvicorn api.main:app --host ${ANDRONOMA_API_HOST:-0.0.0.0} --port ${ANDRONOMA_API_PORT:-8000} --reload
+    env_file:
+      - .env
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4318}
+    ports:
+      - "8000:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_started
+      otel-collector:
+        condition: service_started
+
+  worker:
+    image: python:3.11-slim
+    container_name: andronoma-worker
+    working_dir: /app
+    volumes:
+      - ./:/app
+    command:
+      - bash
+      - -c
+      - >-
+        pip install --no-cache-dir -r requirements.txt &&
+        celery -A workers.celery_app.celery_app worker --loglevel=info --concurrency=${CELERY_WORKER_CONCURRENCY:-4} --queues=${CELERY_QUEUE_DEFAULT:-andronoma}
+    env_file:
+      - .env
+    depends_on:
+      redis:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+
+  beat:
+    image: python:3.11-slim
+    container_name: andronoma-beat
+    working_dir: /app
+    volumes:
+      - ./:/app
+    command:
+      - bash
+      - -c
+      - >-
+        pip install --no-cache-dir -r requirements.txt &&
+        celery -A workers.celery_app.celery_app beat --loglevel=info
+    env_file:
+      - .env
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  flower:
+    image: mher/flower:latest
+    container_name: andronoma-flower
+    environment:
+      - CELERY_BROKER_URL=${ANDRONOMA_BROKER_URL}
+      - FLOWER_PORT=5555
+    ports:
+      - "5555:5555"
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:15
+    container_name: andronoma-postgres
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./infra/migrations:/docker-entrypoint-initdb.d
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: andronoma-redis
+    command: redis-server --save '' --appendonly no
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    image: minio/minio:RELEASE.2024-04-18T19-09-19Z
+    container_name: andronoma-minio
+    environment:
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio_data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+
+  minio-setup:
+    image: minio/mc:RELEASE.2024-04-18T19-09-19Z
+    container_name: andronoma-minio-setup
+    depends_on:
+      minio:
+        condition: service_started
+    env_file:
+      - .env
+    entrypoint: >
+      /bin/sh -c "
+      until mc alias set local http://minio:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}; do sleep 1; done;
+      mc mb -p local/${ANDRONOMA_MINIO_BUCKET};
+      mc mb -p local/${MINIO_BUCKET_RAW};
+      mc mb -p local/${MINIO_BUCKET_PROCESSED};
+      mc mb -p local/${MINIO_BUCKET_OUTPUTS};
+      exit 0;"
+
+  otel-collector:
+    image: otel/opentelemetry-collector:0.86.0
+    container_name: andronoma-otel-collector
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./infra/observability/otel-collector-config.yaml:/etc/otel-collector-config.yaml:ro
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+      - "8889:8889"
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: andronoma-prometheus
+    volumes:
+      - ./infra/observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.retention.time=2d"
+    ports:
+      - "9090:9090"
+    depends_on:
+      otel-collector:
+        condition: service_started
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    container_name: andronoma-grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+    volumes:
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      prometheus:
+        condition: service_started
+
+volumes:
+  postgres_data:
+  minio_data:
+  grafana_data:

--- a/infra/migrations/0001_init.sql
+++ b/infra/migrations/0001_init.sql
@@ -1,0 +1,159 @@
+-- Initial schema for Andronoma telemetry and orchestration.
+-- This migration is idempotent and can be applied to an empty Postgres database.
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Enumerations --------------------------------------------------------------
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'run_status') THEN
+        CREATE TYPE run_status AS ENUM ('pending', 'running', 'completed', 'failed', 'cancelled');
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'stage_status') THEN
+        CREATE TYPE stage_status AS ENUM ('pending', 'running', 'completed', 'failed', 'skipped');
+    END IF;
+END$$;
+
+-- Core identity tables -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    email VARCHAR(320) UNIQUE NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS session_tokens (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token VARCHAR(128) NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Pipeline orchestration ---------------------------------------------------
+CREATE TABLE IF NOT EXISTS pipeline_runs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    owner_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status run_status NOT NULL DEFAULT 'pending',
+    input_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    budgets JSONB NOT NULL DEFAULT '{}'::jsonb,
+    telemetry JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_runs_owner ON pipeline_runs(owner_id);
+CREATE INDEX IF NOT EXISTS idx_pipeline_runs_status ON pipeline_runs(status);
+
+CREATE TABLE IF NOT EXISTS stage_states (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    run_id UUID NOT NULL REFERENCES pipeline_runs(id) ON DELETE CASCADE,
+    name VARCHAR(64) NOT NULL,
+    status stage_status NOT NULL DEFAULT 'pending',
+    started_at TIMESTAMPTZ,
+    finished_at TIMESTAMPTZ,
+    telemetry JSONB NOT NULL DEFAULT '{}'::jsonb,
+    budget_spent NUMERIC(12,2) NOT NULL DEFAULT 0,
+    notes TEXT NOT NULL DEFAULT ''
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stage_states_run_stage ON stage_states(run_id, name);
+CREATE INDEX IF NOT EXISTS idx_stage_states_status ON stage_states(status);
+
+CREATE TABLE IF NOT EXISTS run_logs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    run_id UUID NOT NULL REFERENCES pipeline_runs(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    level VARCHAR(16) NOT NULL DEFAULT 'info',
+    message TEXT NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_logs_run ON run_logs(run_id);
+CREATE INDEX IF NOT EXISTS idx_run_logs_level ON run_logs(level);
+
+CREATE TABLE IF NOT EXISTS asset_records (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    run_id UUID NOT NULL REFERENCES pipeline_runs(id) ON DELETE CASCADE,
+    stage VARCHAR(64) NOT NULL,
+    asset_type VARCHAR(32) NOT NULL,
+    storage_key VARCHAR(512) NOT NULL,
+    extra JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_asset_records_run ON asset_records(run_id);
+CREATE INDEX IF NOT EXISTS idx_asset_records_stage ON asset_records(stage);
+
+-- Model telemetry ----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS model_runs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    run_id UUID REFERENCES pipeline_runs(id) ON DELETE SET NULL,
+    stage VARCHAR(64) NOT NULL,
+    provider VARCHAR(64) NOT NULL,
+    model VARCHAR(128) NOT NULL,
+    prompt_hash VARCHAR(64) NOT NULL,
+    prompt JSONB NOT NULL DEFAULT '{}'::jsonb,
+    response JSONB NOT NULL DEFAULT '{}'::jsonb,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_cents NUMERIC(12,4) NOT NULL DEFAULT 0,
+    latency_ms INTEGER,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_model_runs_run_stage ON model_runs(run_id, stage);
+CREATE INDEX IF NOT EXISTS idx_model_runs_provider ON model_runs(provider);
+
+CREATE TABLE IF NOT EXISTS model_run_costs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    model_run_id UUID NOT NULL REFERENCES model_runs(id) ON DELETE CASCADE,
+    line_item VARCHAR(64) NOT NULL,
+    amount_cents NUMERIC(12,4) NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_model_run_costs_model_run ON model_run_costs(model_run_id);
+
+CREATE TABLE IF NOT EXISTS stage_costs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    run_id UUID NOT NULL REFERENCES pipeline_runs(id) ON DELETE CASCADE,
+    stage VARCHAR(64) NOT NULL,
+    total_cost_cents NUMERIC(12,4) NOT NULL DEFAULT 0,
+    tokens_input INTEGER NOT NULL DEFAULT 0,
+    tokens_output INTEGER NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stage_costs_run_stage ON stage_costs(run_id, stage);
+
+-- Audit logging ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    actor_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    actor_type VARCHAR(32) NOT NULL DEFAULT 'user',
+    action VARCHAR(64) NOT NULL,
+    resource_type VARCHAR(64) NOT NULL,
+    resource_id VARCHAR(128) NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_logs_resource ON audit_logs(resource_type, resource_id);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_actor ON audit_logs(actor_type, actor_id);
+
+-- Rate limiting ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS api_rate_limits (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    api_key VARCHAR(128) NOT NULL,
+    window_start TIMESTAMPTZ NOT NULL,
+    window_end TIMESTAMPTZ NOT NULL,
+    request_count INTEGER NOT NULL DEFAULT 0,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_api_rate_limits_key_window ON api_rate_limits(api_key, window_start, window_end);
+
+COMMIT;

--- a/infra/observability/otel-collector-config.yaml
+++ b/infra/observability/otel-collector-config.yaml
@@ -1,0 +1,27 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch:
+    send_batch_size: 512
+    timeout: 5s
+
+exporters:
+  prometheus:
+    endpoint: 0.0.0.0:8889
+  logging:
+    loglevel: info
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging]

--- a/infra/observability/prometheus.yml
+++ b/infra/observability/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: otel-collector
+    static_configs:
+      - targets: ['otel-collector:8889']
+  - job_name: api
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['api:8000']

--- a/prompts/stages/audiences.yaml
+++ b/prompts/stages/audiences.yaml
@@ -1,0 +1,26 @@
+name: audience_generation
+stage: audiences
+description: Produce a diversified, quota-aware audience matrix aligned with positioning outputs.
+inputs:
+  - positioning_pillars
+  - motivation_map
+  - blockers
+  - market_summary
+output: csv_rows
+template: |-
+  You are designing performance marketing audiences for a paid acquisition sprint.
+  Consider the positioning pillars:
+  {positioning_pillars}
+
+  Motivation map:
+  {motivation_map}
+
+  Blockers to solve:
+  {blockers}
+
+  Market context:
+  {market_summary}
+
+  Generate at least 120 audiences and format the response as CSV with the columns:
+  "#,Audience Name,Who They Are,Seed Terms,Primary Motivation,Top 2 Blockers,Message Angle,Creative Concept,Format Notes,Proof/Offer,Success Metric,A/B Variable,Exclusions".
+  Ensure quotas per the specification and annotate blocker bindings inline.

--- a/prompts/stages/creatives.yaml
+++ b/prompts/stages/creatives.yaml
@@ -1,0 +1,27 @@
+name: creative_briefs
+stage: creatives
+description: Generate scroll-stopper concepts mapped to required creative buckets.
+inputs:
+  - audiences_csv
+  - positioning_summary
+  - creative_constraints
+  - brand_voice
+output: csv_rows
+template: |-
+  You are the creative director converting strategy into scroll-stopping concepts.
+  Use the prioritized audience insights:
+  {audiences_csv}
+
+  Summarize the positioning with:
+  {positioning_summary}
+
+  Work within these creative constraints:
+  {creative_constraints}
+
+  Honor the brand voice guidelines:
+  {brand_voice}
+
+  Produce at least 50 rows in CSV format with columns
+  "#,Headline,Visual,Angle,Blocker,Audience Fit".
+  Tag each concept with its creative bucket (Shock, Proof/Engineering, Emotional Story, Absurd/Surreal, Pure Aesthetic)
+  and ensure blocker coverage per the specification.

--- a/prompts/stages/export.yaml
+++ b/prompts/stages/export.yaml
@@ -1,0 +1,30 @@
+name: export_summary
+stage: export
+description: Craft the executive summary and export manifest accompanying deliverables.
+inputs:
+  - audiences_csv
+  - creatives_csv
+  - qa_report
+  - bundle_manifest
+output: markdown
+template: |-
+  You are preparing the executive summary and export manifest for a completed Andronoma run.
+
+  Audiences CSV preview:
+  {audiences_csv}
+
+  Creatives CSV preview:
+  {creatives_csv}
+
+  QA report summary:
+  {qa_report}
+
+  Bundle manifest metadata:
+  {bundle_manifest}
+
+  Create Markdown with sections:
+    1. **Run Overview** — high-level objectives and success metrics.
+    2. **Audience Insights** — highlight quota coverage and standout segments.
+    3. **Creative Themes** — summarize creative buckets and narrative arcs.
+    4. **QA Status** — outline blockers, fixes applied, and outstanding risks.
+    5. **Delivery Checklist** — bullet list referencing exported assets and destinations (CSV, Sheets, Meta uploads).

--- a/prompts/stages/images.yaml
+++ b/prompts/stages/images.yaml
@@ -1,0 +1,24 @@
+name: image_art_direction
+stage: images
+description: Produce art direction and overlay guidance for generated stills.
+inputs:
+  - creative_concepts
+  - brand_visuals
+  - overlay_requirements
+output: structured_json
+template: |-
+  You are generating art direction briefs for 1080x1350 images to accompany the creative concepts below:
+  {creative_concepts}
+
+  Visual assets and brand references:
+  {brand_visuals}
+
+  Overlay requirements:
+  {overlay_requirements}
+
+  For each concept, output JSON objects with keys:
+    - "concept_id": identifier from the input list.
+    - "scene_description": grounded, photoreal description of the scene.
+    - "composition_notes": framing, perspective, and lighting.
+    - "overlay": {"headline", "subcopy", "cta", "placement"} respecting safe areas.
+    - "style_tags": array of 3-5 descriptive tags.

--- a/prompts/stages/process.yaml
+++ b/prompts/stages/process.yaml
@@ -1,0 +1,28 @@
+name: insight_processing
+stage: process
+description: Transform research artifacts into the structured positioning analysis required by downstream stages.
+inputs:
+  - research_summary
+  - sentiment_highlights
+  - quantitative_findings
+  - brand_goals
+output: structured_json
+template: |-
+  You are the processing agent turning research into actionable strategy.
+  Using the provided research summary:
+  {research_summary}
+
+  Account for notable sentiments:
+  {sentiment_highlights}
+
+  And quantitative signals:
+  {quantitative_findings}
+
+  Respect the brand goals:
+  {brand_goals}
+
+  Return JSON with:
+    - "positioning_pillars": array of {"pillar", "evidence", "implications"}.
+    - "motivation_map": object keyed by Feelings, Functional, Social, Aspiration with bullet arrays.
+    - "blockers": array of blockers sorted by severity with recommended counter-messaging.
+    - "market_summary": concise synthesis of category dynamics and whitespace.

--- a/prompts/stages/qa.yaml
+++ b/prompts/stages/qa.yaml
@@ -1,0 +1,28 @@
+name: qa_validator
+stage: qa
+description: Run automated QA heuristics across generated outputs before export.
+inputs:
+  - audiences_csv
+  - creatives_csv
+  - image_manifests
+  - policy_constraints
+output: structured_json
+template: |-
+  You are the QA automation layer reviewing generated campaign assets.
+  Evaluate the following audiences CSV:
+  {audiences_csv}
+
+  Evaluate the following creatives CSV:
+  {creatives_csv}
+
+  Image manifests:
+  {image_manifests}
+
+  Apply these policy constraints:
+  {policy_constraints}
+
+  Return JSON with:
+    - "audience_findings": array of {"row", "issue", "severity", "recommendation"}.
+    - "creative_findings": same structure as above.
+    - "image_findings": same structure as above plus "fix" suggestions.
+    - "overall_status": pass/fail plus summary commentary.

--- a/prompts/stages/scrape.yaml
+++ b/prompts/stages/scrape.yaml
@@ -1,0 +1,28 @@
+name: scrape_research
+stage: scrape
+description: Collect brand, product, and competitive insights from the provided surfaces.
+inputs:
+  - brand_url
+  - crawl_constraints
+  - research_brief
+  - previous_findings
+output: structured_json
+template: |-
+  You are the research agent for the Andronoma pipeline.
+  Crawl and summarize the most salient findings for the brand at {brand_url} while respecting the crawl constraints below.
+
+  CRAWL CONSTRAINTS:
+  {crawl_constraints}
+
+  OBJECTIVES:
+  {research_brief}
+
+  PREVIOUS FINDINGS TO AVOID DUPLICATING:
+  {previous_findings}
+
+  Produce structured JSON with keys:
+    - "brand_voice": synopsis of tone and signature phrases.
+    - "product_highlights": array of bullet strings with key differentiators.
+    - "competitive_landscape": array of competitor entries with name, positioning, and pricing notes.
+    - "customer_language": snippets capturing authentic phrasing from reviews or communities.
+    - "opportunities": hypotheses about whitespace or under-served needs.


### PR DESCRIPTION
## Summary
- add a documented `.env.example` covering secrets, integrations, and feature flags
- introduce a docker-compose stack with FastAPI, Celery workers, Postgres, Redis, MinIO, and observability defaults
- define the initial SQL schema, OpenAPI surface, and per-stage prompt templates for the orchestration pipeline

## Testing
- pytest || echo "no tests"

------
https://chatgpt.com/codex/tasks/task_e_68e1ed3e8bec83248dda089762f90054