### PR TITLE
Fix get_run dependency parameter order

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -32,7 +32,7 @@ def get_current_user(
         return user
 
 
-async def get_run(session: AsyncSession = Depends(get_db), run_id: UUID) -> PipelineRun:
+async def get_run(run_id: UUID, session: AsyncSession = Depends(get_db)) -> PipelineRun:
     run = await session.get(PipelineRun, run_id)
     if not run:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Run not found")


### PR DESCRIPTION
## Summary
- reorder the get_run dependency parameters so the run_id argument precedes the session dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1f63f4f588324b98337b77473bf3d