### PR TITLE
Implement NLP processing stage orchestration

### DIFF
--- a/nlp/ad_readiness.py
+++ b/nlp/ad_readiness.py
@@ -1,0 +1,120 @@
+"""Ad readiness heuristics derived from research insights."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence
+
+
+def evaluate_ad_readiness(
+    documents: Sequence[Dict[str, Any]],
+    brand_position: Dict[str, Any],
+    motivation_map: Dict[str, Any],
+    blockers: Sequence[Dict[str, Any]],
+    conversion_hypotheses: Sequence[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Return readiness heuristics, labelled Direct vs Inferred."""
+
+    direct_hypotheses = [hyp for hyp in conversion_hypotheses if hyp.get("type") == "Direct"]
+    direct_sources = _collect_sources(direct_hypotheses)
+    blocker_sources = blockers[0]["sources"] if blockers else []
+
+    readiness_score = min(100, 60 + len(direct_hypotheses) * 10)
+
+    return {
+        "overall": {
+            "score": readiness_score,
+            "type": "Inferred",
+            "sources": direct_sources or _fallback_sources(brand_position),
+            "reasoning": (
+                "Direct CTA evidence elevates readiness." if direct_hypotheses else "Reliant on inferred motivations due to missing CTA signals."
+            ),
+        },
+        "cta": {
+            "status": "Confident" if direct_hypotheses else "Needs validation",
+            "type": "Direct" if direct_hypotheses else "Inferred",
+            "sources": direct_sources or blocker_sources,
+            "recommendations": _cta_recommendations(direct_hypotheses, blockers),
+        },
+        "value_proposition": {
+            "status": "Aligned",
+            "type": "Direct" if brand_position.get("promise", {}).get("sources") else "Inferred",
+            "sources": brand_position.get("promise", {}).get("sources", []),
+            "recommendations": [
+                "Lead with the most emotionally resonant motivator to maximise click intent.",
+            ],
+        },
+        "proof": {
+            "status": "Robust" if brand_position.get("proof_pillars") else "Sparse",
+            "type": "Direct" if any(p.get("type") == "Direct" for p in brand_position.get("proof_pillars", [])) else "Inferred",
+            "sources": _collect_sources(brand_position.get("proof_pillars", [])),
+            "recommendations": [
+                "Pair each CTA with a proof point clarifying measurable impact.",
+            ],
+        },
+        "legibility": {
+            "status": _legibility_status(documents),
+            "type": "Direct",
+            "sources": _legibility_sources(documents),
+            "recommendations": [
+                "Highlight the product noun early in copy to reduce cognitive load.",
+            ],
+        },
+    }
+
+
+def _collect_sources(items: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    sources: List[Dict[str, Any]] = []
+    seen = set()
+    for item in items:
+        for source in item.get("sources", []):
+            key = (source.get("source"), source.get("hash"), source.get("evidence"))
+            if key not in seen:
+                seen.add(key)
+                sources.append(source)
+    return sources
+
+
+def _fallback_sources(brand_position: Dict[str, Any]) -> List[Dict[str, Any]]:
+    sources = brand_position.get("promise", {}).get("sources", [])
+    if sources:
+        return sources
+    return _collect_sources(brand_position.get("differentiators", []))
+
+
+def _cta_recommendations(
+    direct_hypotheses: Sequence[Dict[str, Any]],
+    blockers: Sequence[Dict[str, Any]],
+) -> List[str]:
+    recommendations: List[str] = []
+    if not direct_hypotheses:
+        recommendations.append("Prototype CTA variants using the dominant functional motivator.")
+    if blockers:
+        recommendations.append(f"Address {blockers[0]['blocker']} objection immediately after CTA copy.")
+    if not recommendations:
+        recommendations.append("A/B test tonal shifts between urgency and reassurance.")
+    return recommendations
+
+
+def _legibility_status(documents: Sequence[Dict[str, Any]]) -> str:
+    sentence_lengths: List[int] = []
+    for doc in documents:
+        for sentence in doc.get("sentences", []):
+            sentence_lengths.append(len(sentence.split()))
+    if not sentence_lengths:
+        return "Unknown"
+    avg = sum(sentence_lengths) / len(sentence_lengths)
+    return "Clear" if avg <= 22 else "Verbose"
+
+
+def _legibility_sources(documents: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    sources: List[Dict[str, Any]] = []
+    for doc in documents:
+        for sentence in doc.get("sentences", [])[:1]:
+            sources.append(
+                {
+                    "source": doc.get("url") or doc["id"],
+                    "hash": doc["hash"],
+                    "evidence": sentence,
+                }
+            )
+    return sources[:3]
+

--- a/nlp/brand_fit.py
+++ b/nlp/brand_fit.py
@@ -1,0 +1,109 @@
+"""Brand fit scoring heuristics."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence
+
+
+def score_brand_fit(
+    documents: Sequence[Dict[str, Any]],
+    pipeline_input: Dict[str, Any],
+    brand_position: Dict[str, Any],
+    motivation_map: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Return brand-fit metrics with labelled evidence."""
+
+    tone_alignment = _tone_alignment(documents, motivation_map)
+    aesthetic_alignment = _aesthetic_alignment(documents, pipeline_input)
+
+    direct_sources = tone_alignment.get("sources", []) + aesthetic_alignment.get("sources", [])
+    score = min(100, 55 + len(direct_sources) * 5)
+
+    return {
+        "overall": {
+            "score": score,
+            "type": "Inferred",
+            "sources": direct_sources or brand_position.get("promise", {}).get("sources", []),
+            "reasoning": "Score synthesises tonal evidence with desired positioning cues.",
+        },
+        "tone_alignment": tone_alignment,
+        "aesthetic_alignment": aesthetic_alignment,
+        "gaps": _fit_gaps(brand_position, tone_alignment, aesthetic_alignment),
+    }
+
+
+def _tone_alignment(
+    documents: Sequence[Dict[str, Any]], motivation_map: Dict[str, Any]
+) -> Dict[str, Any]:
+    emotional = motivation_map.get("emotional", {}).get("insights", [])
+    social = motivation_map.get("social", {}).get("insights", [])
+    sources: List[Dict[str, Any]] = []
+    for bucket in (emotional, social):
+        for insight in bucket[:2]:
+            sources.extend(insight.get("sources", []))
+    return {
+        "statement": "Tone mirrors audience emotional and social motivators.",
+        "type": "Direct" if sources else "Inferred",
+        "sources": sources,
+        "recommendations": [
+            "Maintain empathetic language that reflects the research vernacular.",
+        ],
+    }
+
+
+def _aesthetic_alignment(
+    documents: Sequence[Dict[str, Any]], pipeline_input: Dict[str, Any]
+) -> Dict[str, Any]:
+    metadata = pipeline_input.get("config", {}).get("metadata", {})
+    desired_tone = metadata.get("tone", "modern")
+    style_keywords = metadata.get("style_keywords", [])
+
+    sources: List[Dict[str, Any]] = []
+    for doc in documents:
+        if any(keyword.lower() in doc.get("body", "").lower() for keyword in style_keywords):
+            sources.append(
+                {
+                    "source": doc.get("url") or doc["id"],
+                    "hash": doc["hash"],
+                    "evidence": doc.get("sentences", [doc.get("body", "")])[0],
+                }
+            )
+
+    return {
+        "statement": f"Research indicates alignment with {desired_tone} aesthetic cues.",
+        "type": "Direct" if sources else "Inferred",
+        "sources": sources,
+        "recommendations": [
+            "Reference collected imagery or descriptors within creative briefs.",
+        ],
+    }
+
+
+def _fit_gaps(
+    brand_position: Dict[str, Any],
+    tone_alignment: Dict[str, Any],
+    aesthetic_alignment: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    gaps: List[Dict[str, Any]] = []
+    if tone_alignment.get("type") != "Direct":
+        gaps.append(
+            {
+                "statement": "Validate tone cues through qualitative interviews.",
+                "type": "Inferred",
+                "sources": brand_position.get("promise", {}).get("sources", []),
+            }
+        )
+    if aesthetic_alignment.get("type") != "Direct":
+        proof_sources: List[Dict[str, Any]] = []
+        for pillar in brand_position.get("proof_pillars", []):
+            proof_sources.extend(pillar.get("sources", []))
+            if proof_sources:
+                break
+        gaps.append(
+            {
+                "statement": "Supplement aesthetic guidance with asset audits or mood boards.",
+                "type": "Inferred",
+                "sources": proof_sources,
+            }
+        )
+    return gaps
+

--- a/nlp/conversion_hypotheses.py
+++ b/nlp/conversion_hypotheses.py
@@ -1,0 +1,142 @@
+"""Generate conversion hypotheses from research artifacts."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Sequence
+
+
+CTA_KEYWORDS = {
+    "try", "start", "join", "book", "schedule", "demo", "buy", "explore", "learn", "discover"
+}
+
+
+def generate_conversion_hypotheses(
+    documents: Sequence[Dict[str, Any]],
+    brand_position: Dict[str, Any],
+    motivation_map: Dict[str, Any],
+    blockers: Sequence[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return structured conversion hypotheses with evidence labels."""
+
+    cta_sentences: List[Dict[str, Any]] = []
+    for doc in documents:
+        for sentence in doc.get("sentences", []):
+            if any(keyword in sentence.lower() for keyword in CTA_KEYWORDS):
+                cta_sentences.append(
+                    {
+                        "statement": sentence,
+                        "type": "Direct",
+                        "sources": [
+                            {
+                                "source": doc.get("url") or doc["id"],
+                                "hash": doc["hash"],
+                                "evidence": sentence.strip(),
+                            }
+                        ],
+                        "doc": doc,
+                    }
+                )
+
+    hypotheses: List[Dict[str, Any]] = []
+    motivation_priorities = _motivation_priority(motivation_map)
+    blocker_top = blockers[0] if blockers else None
+
+    for idx, evidence in enumerate(cta_sentences[:3], start=1):
+        hypotheses.append(
+            {
+                "id": f"hypothesis-{idx}",
+                "type": "Direct",
+                "value_proposition": f"{_primary_promise(brand_position)} reinforced by {motivation_priorities[0]}",
+                "proof_assets": _proof_assets(brand_position),
+                "cta_tone": _cta_tone(evidence["statement"]),
+                "sources": evidence["sources"],
+                "reasoning": "CTA language observed directly within research corpus.",
+            }
+        )
+
+    if len(hypotheses) < 3:
+        inferred_sources = _aggregate_sources(motivation_map, brand_position)
+        for idx in range(len(hypotheses), 3):
+            blocker_clause = (
+                f" while neutralising {blocker_top['blocker']} concerns"
+                if blocker_top
+                else ""
+            )
+            hypotheses.append(
+                {
+                    "id": f"hypothesis-{idx+1}",
+                    "type": "Inferred",
+                    "value_proposition": f"Translate {motivation_priorities[idx % len(motivation_priorities)]}{blocker_clause}",
+                    "proof_assets": _proof_assets(brand_position),
+                    "cta_tone": "Reassuring" if blocker_top else "Uplifting",
+                    "sources": inferred_sources,
+                    "reasoning": "Derived from dominant motivations and blockers due to absent direct CTA signals.",
+                }
+            )
+
+    return hypotheses
+
+
+def _motivation_priority(motivation_map: Dict[str, Any]) -> List[str]:
+    ordered: List[str] = []
+    for key in ["functional", "emotional", "aspirational", "social"]:
+        bucket = motivation_map.get(key, {})
+        insights = bucket.get("insights", [])
+        label = key.capitalize()
+        if insights and insights[0].get("type") == "Direct":
+            label = f"{label} ({insights[0]['statement'][:60]})"
+        ordered.append(label)
+    return ordered or ["Core Value"]
+
+
+def _primary_promise(brand_position: Dict[str, Any]) -> str:
+    promise = brand_position.get("promise", {})
+    return promise.get("statement", "deliver measurable outcomes")
+
+
+def _proof_assets(brand_position: Dict[str, Any]) -> List[Dict[str, Any]]:
+    assets: List[Dict[str, Any]] = []
+    for pillar in brand_position.get("proof_pillars", [])[:3]:
+        assets.append(
+            {
+                "type": "Direct" if pillar.get("type") == "Direct" else "Inferred",
+                "statement": pillar.get("statement"),
+                "sources": pillar.get("sources", []),
+            }
+        )
+    if not assets:
+        assets.append(
+            {
+                "type": "Inferred",
+                "statement": "Surface customer testimonials highlighting outcome metrics.",
+                "sources": brand_position.get("promise", {}).get("sources", []),
+            }
+        )
+    return assets
+
+
+def _cta_tone(sentence: str) -> str:
+    lower = sentence.lower()
+    if any(keyword in lower for keyword in {"today", "now", "immediately"}):
+        return "Urgent"
+    if any(keyword in lower for keyword in {"explore", "learn", "discover"}):
+        return "Curious"
+    return "Supportive"
+
+
+def _aggregate_sources(
+    motivation_map: Dict[str, Any], brand_position: Dict[str, Any]
+) -> List[Dict[str, Any]]:
+    sources: List[Dict[str, Any]] = []
+    for bucket in motivation_map.values():
+        for insight in bucket.get("insights", [])[:1]:
+            sources.extend(insight.get("sources", [])[:1])
+    sources.extend(brand_position.get("promise", {}).get("sources", [])[:1])
+    unique: List[Dict[str, Any]] = []
+    seen = set()
+    for source in sources:
+        key = (source.get("source"), source.get("hash"), source.get("evidence"))
+        if key not in seen:
+            seen.add(key)
+            unique.append(source)
+    return unique
+

--- a/nlp/pipeline.py
+++ b/nlp/pipeline.py
@@ -1,17 +1,836 @@
-"""NLP enrichment stage."""
+"""NLP enrichment stage for the Andronoma pipeline."""
 from __future__ import annotations
 
-from typing import Dict
+import datetime as dt
+import hashlib
+import json
+import re
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, List, Sequence, Tuple
+from urllib.parse import urlparse
 
+from sqlalchemy import select
+
+from shared.logs import emit_log
+from shared.models import AssetRecord
 from shared.stages.base import BaseStage
+
+from . import ad_readiness, brand_fit, conversion_hypotheses
 
 
 class ProcessStage(BaseStage):
+    """Transform scraped research into positioning intelligence."""
+
     name = "process"
 
-    def execute(self) -> Dict[str, float]:
-        self.ensure_budget(20.0)
-        return {"topics_extracted": 12, "sentiment_score": 0.8}
+    COST_CEILING_CENTS = 150.0
+    COST_PER_TOKEN_CENTS = 0.002
+    SOFT_TIMEOUT_SECONDS = 300.0
+
+    STOPWORDS: frozenset[str] = frozenset(
+        {
+            "the",
+            "and",
+            "a",
+            "an",
+            "is",
+            "to",
+            "of",
+            "in",
+            "for",
+            "on",
+            "with",
+            "as",
+            "by",
+            "at",
+            "from",
+            "that",
+            "this",
+            "it",
+            "be",
+            "are",
+            "or",
+            "we",
+            "you",
+            "our",
+            "their",
+            "your",
+            "they",
+        }
+    )
+
+    def execute(self) -> Dict[str, Any]:
+        start = time.monotonic()
+        # Budget check is performed in dollars; convert the cents ceiling accordingly.
+        self.ensure_budget(self.COST_CEILING_CENTS / 100.0)
+
+        run = self.context.run
+        session = self.context.session
+
+        emit_log(session, run.id, "Loading research corpus for processing")
+        documents = self._load_corpus()
+        if not documents:
+            raise ValueError("No research documents available for processing stage")
+
+        prepared_docs = self._prepare_documents(documents)
+        total_tokens = sum(doc["token_count"] for doc in prepared_docs)
+        projected_cost = total_tokens * self.COST_PER_TOKEN_CENTS
+        if projected_cost > self.COST_CEILING_CENTS:
+            raise ValueError(
+                f"Projected spend {projected_cost:.2f}¢ exceeds stage ceiling "
+                f"{self.COST_CEILING_CENTS:.0f}¢"
+            )
+
+        emit_log(
+            session,
+            run.id,
+            "Corpus prepared",
+            metadata={"documents": len(prepared_docs), "tokens": total_tokens},
+        )
+
+        global_terms, per_doc_terms = self._compute_term_frequencies(prepared_docs)
+        brand_position = self._build_brand_position(prepared_docs, global_terms)
+        motivation_map = self._build_motivation_map(prepared_docs)
+        blockers_ranking = self._rank_blockers(prepared_docs)
+        market_summary = self._build_market_summary(
+            prepared_docs, blockers_ranking, brand_position
+        )
+
+        conversions = conversion_hypotheses.generate_conversion_hypotheses(
+            prepared_docs, brand_position, motivation_map, blockers_ranking
+        )
+        readiness = ad_readiness.evaluate_ad_readiness(
+            prepared_docs,
+            brand_position,
+            motivation_map,
+            blockers_ranking,
+            conversions,
+        )
+        fit = brand_fit.score_brand_fit(
+            prepared_docs,
+            run.input_payload,
+            brand_position,
+            motivation_map,
+        )
+
+        generated_at = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
+        result_bundle = {
+            "run_id": str(run.id),
+            "generated_at": generated_at.isoformat(),
+            "source_documents": [
+                {
+                    "id": doc["id"],
+                    "url": doc.get("url"),
+                    "title": doc.get("title"),
+                    "hash": doc["hash"],
+                    "word_count": doc["word_count"],
+                }
+                for doc in prepared_docs
+            ],
+            "artifacts": {
+                "brand_position": brand_position,
+                "motivation_map": motivation_map,
+                "blockers_ranking": blockers_ranking,
+                "market_summary": market_summary,
+                "conversion_hypotheses": conversions,
+                "ad_readiness": readiness,
+                "brand_fit": fit,
+            },
+            "intermediate": {
+                "term_frequencies": global_terms,
+                "document_vectors": per_doc_terms,
+            },
+        }
+
+        output_path = self._persist_results(run.id, result_bundle)
+
+        latency = time.monotonic() - start
+
+        diagnostics, deficits = self._compile_diagnostics(result_bundle)
+        if latency > self.SOFT_TIMEOUT_SECONDS:
+            diagnostics["timeout_exceeded"] = True
+            deficits = list(deficits) + [
+                "Processing latency exceeded soft timeout threshold; downstream stages should validate completeness.",
+            ]
+        else:
+            diagnostics["timeout_exceeded"] = False
+
+        telemetry = {
+            "documents": len(prepared_docs),
+            "unique_sources": len({doc.get("url") or doc["hash"] for doc in prepared_docs}),
+            "andronoma_stage_latency_seconds": round(latency, 3),
+            "andronoma_stage_cost_cents": round(projected_cost, 2),
+            "tokens_consumed": total_tokens,
+            "stage_ceiling_cents": self.COST_CEILING_CENTS,
+            "output_path": str(output_path),
+            "diagnostics": diagnostics,
+            "deficits": deficits,
+        }
+
+        emit_log(
+            session,
+            run.id,
+            "Processing artifacts generated",
+            metadata={
+                "output_path": str(output_path),
+                "direct_insights": diagnostics.get("direct_insights", 0),
+                "inferred_insights": diagnostics.get("inferred_insights", 0),
+            },
+        )
+
+        return telemetry
+
+    # ------------------------------------------------------------------
+    # Corpus loading utilities
+    # ------------------------------------------------------------------
+    def _load_corpus(self) -> List[Dict[str, Any]]:
+        session = self.context.session
+        run_id = self.context.run.id
+
+        stmt = (
+            select(AssetRecord)
+            .where(AssetRecord.run_id == run_id, AssetRecord.stage == "scrape")
+            .order_by(AssetRecord.created_at.desc())
+        )
+        record = session.execute(stmt).scalars().first()
+
+        documents: List[Dict[str, Any]] | None = None
+        storage_key = None
+        if record:
+            storage_key = record.storage_key
+            documents = self._load_from_storage(storage_key)
+
+        if documents is None:
+            documents = self._load_from_local()
+
+        if documents is None:
+            raise FileNotFoundError(
+                "Unable to locate research payload in storage or local filesystem"
+            )
+
+        if not isinstance(documents, list):
+            if isinstance(documents, dict) and "documents" in documents:
+                documents = documents["documents"]  # type: ignore[assignment]
+            else:
+                raise TypeError("Research payload must be a list of documents")
+
+        emit_log(
+            self.context.session,
+            run_id,
+            "Research corpus loaded",
+            metadata={"documents": len(documents), "storage_key": storage_key},
+        )
+
+        return documents
+
+    def _load_from_storage(self, storage_key: str | None) -> List[Dict[str, Any]] | None:
+        if not storage_key:
+            return None
+        parsed = urlparse(storage_key)
+        if parsed.scheme not in {"s3", "minio"}:
+            return self._load_from_path(storage_key)
+
+        try:
+            from shared.storage import client, settings
+
+            bucket = parsed.netloc or settings.minio_bucket
+            object_name = parsed.path.lstrip("/")
+            response = client.get_object(bucket, object_name)
+            try:
+                payload = response.read()
+            finally:
+                response.close()
+                response.release_conn()
+        except Exception:  # pragma: no cover - network failures
+            return None
+
+        try:
+            return json.loads(payload.decode("utf-8"))
+        except json.JSONDecodeError:  # pragma: no cover - corrupt payloads
+            return None
+
+    def _load_from_path(self, path_like: str) -> List[Dict[str, Any]] | None:
+        parsed = urlparse(path_like)
+        if parsed.scheme == "file":
+            path = Path(parsed.path)
+        else:
+            path = Path(path_like)
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return None
+
+    def _load_from_local(self) -> List[Dict[str, Any]] | None:
+        run_id = str(self.context.run.id)
+        base = Path("/data/raw/research")
+        candidates = [
+            base / f"{run_id}.json",
+            base / run_id / "corpus.json",
+            base / run_id / "documents.json",
+        ]
+        for candidate in candidates:
+            data = self._load_from_path(str(candidate))
+            if data is not None:
+                return data
+        return None
+
+    # ------------------------------------------------------------------
+    # Document preparation
+    # ------------------------------------------------------------------
+    def _prepare_documents(
+        self, documents: Sequence[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        prepared: List[Dict[str, Any]] = []
+        for idx, doc in enumerate(documents):
+            body = str(doc.get("body") or doc.get("content") or "")
+            title = str(doc.get("title") or "").strip()
+            url = doc.get("url") or doc.get("source")
+            merged_text = f"{title}. {body}" if title else body
+            sentences = [
+                sentence.strip()
+                for sentence in re.split(r"(?<=[.!?])\s+", merged_text)
+                if sentence.strip()
+            ]
+            tokens = self._tokenize(merged_text)
+            doc_hash = hashlib.sha1((str(url) + merged_text).encode("utf-8")).hexdigest()[:12]
+            prepared.append(
+                {
+                    "id": doc.get("id") or f"doc-{idx+1}",
+                    "url": url,
+                    "title": title,
+                    "body": body,
+                    "sentences": sentences,
+                    "token_count": len(tokens),
+                    "word_count": len(tokens),
+                    "hash": doc_hash,
+                }
+            )
+        return prepared
+
+    def _tokenize(self, text: str) -> List[str]:
+        tokens = re.findall(r"\b\w+\b", text.lower())
+        return [token for token in tokens if token not in self.STOPWORDS]
+
+    def _compute_term_frequencies(
+        self, documents: Sequence[Dict[str, Any]]
+    ) -> Tuple[List[Tuple[str, int]], Dict[str, Dict[str, int]]]:
+        global_counter: Counter[str] = Counter()
+        per_doc: Dict[str, Dict[str, int]] = {}
+        for doc in documents:
+            tokens = self._tokenize(doc.get("body", ""))
+            counter = Counter(tokens)
+            global_counter.update(counter)
+            per_doc[doc["id"]] = dict(counter)
+        return global_counter.most_common(50), per_doc
+
+    # ------------------------------------------------------------------
+    # Artifact builders
+    # ------------------------------------------------------------------
+    def _build_brand_position(
+        self,
+        documents: Sequence[Dict[str, Any]],
+        global_terms: Sequence[Tuple[str, int]],
+    ) -> Dict[str, Any]:
+        config = self.context.run.input_payload.get("config", {}) if self.context.run else {}
+        brand_name = config.get("name") or "the brand"
+        target_markets: List[str] = config.get("target_markets", [])
+
+        top_terms = [term for term, _ in global_terms if term]
+        category_term = (target_markets[0] if target_markets else None) or (top_terms[0] if top_terms else "market")
+        category_sources = self._sentences_with_keyword(documents, category_term)
+        category_type = "Direct" if category_sources else "Inferred"
+        category_sources = category_sources or self._fallback_sources_from_terms(documents, top_terms[:2])
+
+        promise_term = top_terms[1] if len(top_terms) > 1 else category_term
+        promise_sources = self._sentences_with_keyword(documents, promise_term)
+        promise_type = "Direct" if promise_sources else "Inferred"
+
+        differentiators = []
+        for term in top_terms[:5]:
+            sources = self._sentences_with_keyword(documents, term)
+            if not sources:
+                continue
+            differentiators.append(
+                {
+                    "statement": f"{brand_name} emphasises {term}",
+                    "type": "Direct",
+                    "sources": sources,
+                }
+            )
+        if not differentiators and top_terms:
+            differentiators.append(
+                {
+                    "statement": f"{brand_name} differentiates through {top_terms[0]}",
+                    "type": "Inferred",
+                    "sources": self._fallback_sources_from_terms(documents, top_terms[:1]),
+                    "reasoning": "Dominant keyword frequency suggests emphasis despite limited direct articulation.",
+                }
+            )
+
+        proof_terms = {"evidence", "data", "results", "case", "study", "roi", "customers"}
+        proof_pillars = []
+        for doc in documents:
+            for sentence in doc.get("sentences", []):
+                if any(term in sentence.lower() for term in proof_terms):
+                    proof_pillars.append(
+                        {
+                            "statement": sentence,
+                            "type": "Direct",
+                            "sources": [self._source_entry(doc, sentence)],
+                        }
+                    )
+        if not proof_pillars:
+            proof_pillars.append(
+                {
+                    "statement": f"{brand_name} relies on qualitative testimonials due to limited quantitative proof.",
+                    "type": "Inferred",
+                    "sources": self._fallback_sources_from_terms(documents, top_terms[:2]),
+                    "reasoning": "Research corpus lacks explicit metrics; emphasis inferred from thematic density.",
+                }
+            )
+
+        value_keywords = {
+            "premium": "premium",
+            "luxury": "premium",
+            "affordable": "value",
+            "budget": "value",
+            "cost": "value",
+            "price": "value",
+            "balanced": "balanced",
+            "mid": "balanced",
+        }
+        value_hits: Dict[str, List[Dict[str, str]]] = {"premium": [], "value": [], "balanced": []}
+        for doc in documents:
+            for sentence in doc.get("sentences", []):
+                lower = sentence.lower()
+                for keyword, bucket in value_keywords.items():
+                    if keyword in lower:
+                        value_hits[bucket].append(self._source_entry(doc, sentence))
+
+        if value_hits["premium"] and value_hits["value"]:
+            framing_type = "Inferred"
+            framing_sources = value_hits["premium"][:1] + value_hits["value"][:1]
+            interpretations = [
+                {
+                    "label": "Premium",
+                    "type": "Direct",
+                    "sources": value_hits["premium"][:2],
+                },
+                {
+                    "label": "Value",
+                    "type": "Direct",
+                    "sources": value_hits["value"][:2],
+                },
+            ]
+        elif value_hits["premium"]:
+            framing_type = "Direct"
+            framing_sources = value_hits["premium"]
+            interpretations = []
+        elif value_hits["value"]:
+            framing_type = "Direct"
+            framing_sources = value_hits["value"]
+            interpretations = []
+        else:
+            framing_type = "Inferred"
+            framing_sources = self._fallback_sources_from_terms(documents, top_terms[:2])
+            interpretations = [
+                {
+                    "label": "Balanced",
+                    "type": "Inferred",
+                    "sources": framing_sources,
+                    "reasoning": "No explicit price cues; assume balanced messaging emphasising value proof.",
+                }
+            ]
+
+        value_framing = {
+            "statement": f"{brand_name} positions pricing as {framing_sources[0]['evidence'] if framing_sources else 'balanced value'}",
+            "type": framing_type,
+            "sources": framing_sources,
+            "interpretations": interpretations,
+        }
+
+        return {
+            "category": {
+                "statement": f"{brand_name} competes within {category_term}",
+                "type": category_type,
+                "sources": category_sources,
+            },
+            "promise": {
+                "statement": f"Delivers {promise_term} outcomes for target customers",
+                "type": promise_type,
+                "sources": promise_sources
+                or self._fallback_sources_from_terms(documents, top_terms[:2]),
+            },
+            "differentiators": differentiators,
+            "proof_pillars": proof_pillars,
+            "value_framing": value_framing,
+        }
+
+    def _build_motivation_map(
+        self, documents: Sequence[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        keyword_map = {
+            "functional": {
+                "keywords": [
+                    "efficiency",
+                    "automation",
+                    "integration",
+                    "performance",
+                    "workflow",
+                    "data",
+                ],
+            },
+            "emotional": {
+                "keywords": [
+                    "confidence",
+                    "trust",
+                    "stress",
+                    "frustration",
+                    "feel",
+                    "fear",
+                ],
+            },
+            "aspirational": {
+                "keywords": [
+                    "growth",
+                    "scale",
+                    "vision",
+                    "future",
+                    "lead",
+                    "innov",
+                ],
+            },
+            "social": {
+                "keywords": [
+                    "community",
+                    "team",
+                    "collaboration",
+                    "advocate",
+                    "share",
+                    "peer",
+                ],
+            },
+        }
+
+        personas = self.context.run.input_payload.get("config", {}).get("target_markets", [])
+
+        motivation_map: Dict[str, Any] = {}
+        for motiv, config in keyword_map.items():
+            hits: List[Dict[str, Any]] = []
+            for doc in documents:
+                for sentence in doc.get("sentences", []):
+                    lower = sentence.lower()
+                    if any(keyword in lower for keyword in config["keywords"]):
+                        hits.append(
+                            {
+                                "statement": sentence,
+                                "type": "Direct",
+                                "sources": [self._source_entry(doc, sentence)],
+                                "personas": personas[:3],
+                                "emotion_frequency": "High",
+                            }
+                        )
+            if not hits:
+                fallback_sources = self._fallback_sources_from_terms(
+                    documents, config["keywords"][:2]
+                )
+                hits.append(
+                    {
+                        "statement": f"Motivator inferred from thematic cues around {', '.join(config['keywords'][:2])}",
+                        "type": "Inferred",
+                        "sources": fallback_sources,
+                        "personas": personas[:3],
+                        "emotion_frequency": "Medium",
+                        "reasoning": "Keywords absent verbatim; inference based on related topic density.",
+                    }
+                )
+
+            motivation_map[motiv] = {
+                "intensity": self._motivation_intensity(hits),
+                "insights": hits,
+            }
+
+        return motivation_map
+
+    def _motivation_intensity(self, hits: Sequence[Dict[str, Any]]) -> str:
+        direct = sum(1 for hit in hits if hit["type"] == "Direct")
+        if direct > 3:
+            return "High"
+        if direct > 1:
+            return "Medium"
+        return "Low"
+
+    def _rank_blockers(self, documents: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        blocker_terms = {
+            "cost": ["cost", "price", "budget", "expensive"],
+            "trust": ["trust", "risk", "concern", "uncertain"],
+            "time": ["time", "delay", "slow", "wait"],
+            "integration": ["integrat", "compat", "system", "stack"],
+            "evidence": ["proof", "evidence", "roi", "case", "results"],
+        }
+
+        blockers: Dict[str, Dict[str, Any]] = {}
+        for doc in documents:
+            for sentence in doc.get("sentences", []):
+                lower = sentence.lower()
+                for blocker, keywords in blocker_terms.items():
+                    if any(keyword in lower for keyword in keywords):
+                        record = blockers.setdefault(
+                            blocker,
+                            {
+                                "blocker": blocker,
+                                "mentions": 0,
+                                "type": "Direct",
+                                "sources": [],
+                                "reasoning": "",
+                                "personas": self.context.run.input_payload.get("config", {}).get(
+                                    "target_markets", []
+                                )[:3],
+                            },
+                        )
+                        record["mentions"] += 1
+                        record["sources"].append(self._source_entry(doc, sentence))
+
+        if not blockers:
+            inferred_sources = self._fallback_sources_from_terms(documents, ["risk", "cost"])
+            blockers["uncertainty"] = {
+                "blocker": "uncertainty",
+                "mentions": 1,
+                "type": "Inferred",
+                "sources": inferred_sources,
+                "reasoning": "General market research lacked explicit objections; defaulting to uncertainty.",
+                "personas": self.context.run.input_payload.get("config", {}).get("target_markets", [])[:3],
+            }
+
+        ranked = sorted(blockers.values(), key=lambda item: item["mentions"], reverse=True)
+        output: List[Dict[str, Any]] = []
+        for idx, record in enumerate(ranked, start=1):
+            emotional_weight = self._emotional_weight(record["sources"])
+            output.append(
+                {
+                    "rank": idx,
+                    "blocker": record["blocker"],
+                    "frequency": "High" if record["mentions"] > 3 else "Medium" if record["mentions"] > 1 else "Low",
+                    "mentions": record["mentions"],
+                    "emotional_weight": emotional_weight,
+                    "type": record["type"],
+                    "sources": record["sources"],
+                    "reasoning": record.get("reasoning", ""),
+                    "personas": record.get("personas", []),
+                }
+            )
+        return output
+
+    def _emotional_weight(self, sources: Sequence[Dict[str, str]]) -> str:
+        keywords = {"fear", "risk", "trust", "stress"}
+        hits = 0
+        for source in sources:
+            if any(keyword in source["evidence"].lower() for keyword in keywords):
+                hits += 1
+        if hits > 2:
+            return "High"
+        if hits:
+            return "Medium"
+        return "Low"
+
+    def _build_market_summary(
+        self,
+        documents: Sequence[Dict[str, Any]],
+        blockers: Sequence[Dict[str, Any]],
+        brand_position: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        competitor_signals: List[Dict[str, Any]] = []
+        cultural_signals: List[Dict[str, Any]] = []
+        macro_trends: List[Dict[str, Any]] = []
+        whitespace: List[Dict[str, Any]] = []
+
+        competitor_keywords = {"vs", "versus", "alternative", "competitor", "compared"}
+        culture_keywords = {"trend", "culture", "community", "movement", "signal"}
+        macro_keywords = {"market", "industry", "growth", "demand", "trend", "regulation"}
+
+        for doc in documents:
+            for sentence in doc.get("sentences", []):
+                lower = sentence.lower()
+                if any(keyword in lower for keyword in competitor_keywords):
+                    competitor_signals.append(
+                        {
+                            "statement": sentence,
+                            "type": "Direct",
+                            "sources": [self._source_entry(doc, sentence)],
+                        }
+                    )
+                if any(keyword in lower for keyword in culture_keywords):
+                    cultural_signals.append(
+                        {
+                            "statement": sentence,
+                            "type": "Direct",
+                            "sources": [self._source_entry(doc, sentence)],
+                        }
+                    )
+                if any(keyword in lower for keyword in macro_keywords):
+                    macro_trends.append(
+                        {
+                            "statement": sentence,
+                            "type": "Direct",
+                            "sources": [self._source_entry(doc, sentence)],
+                        }
+                    )
+
+        if not competitor_signals:
+            competitor_signals.append(
+                {
+                    "statement": "Competitor positioning inferred from lack of explicit comparisons; emphasize whitespace messaging.",
+                    "type": "Inferred",
+                    "sources": self._fallback_sources_from_terms(documents, ["unique", "only"]),
+                    "reasoning": "Absence of competitor mentions suggests opportunity to define category narrative.",
+                }
+            )
+
+        if not cultural_signals:
+            cultural_signals.append(
+                {
+                    "statement": "Cultural conversation inferred around community-driven adoption cues.",
+                    "type": "Inferred",
+                    "sources": self._fallback_sources_from_terms(documents, ["community", "advocate"]),
+                    "reasoning": "Keywords indicate latent cultural energy despite limited direct references.",
+                }
+            )
+
+        if not macro_trends:
+            macro_trends.append(
+                {
+                    "statement": "Macro environment inferred as growth-oriented with regulatory watchpoints.",
+                    "type": "Inferred",
+                    "sources": self._fallback_sources_from_terms(documents, ["growth", "market"]),
+                    "reasoning": "General market cues extracted from thematic frequency counts.",
+                }
+            )
+
+        if blockers:
+            top_blocker = blockers[0]
+            whitespace.append(
+                {
+                    "statement": f"Address {top_blocker['blocker']} blocker to unlock whitespace.",
+                    "type": "Inferred" if top_blocker["type"] == "Inferred" else "Direct",
+                    "sources": top_blocker["sources"][:2],
+                    "reasoning": "Highest ranked blocker reveals unmet demand and messaging whitespace.",
+                }
+            )
+
+        if not whitespace:
+            proof_pillars = brand_position.get("proof_pillars", [])
+            pillar_sources: List[Dict[str, str]] = []
+            if proof_pillars:
+                pillar_sources = proof_pillars[0].get("sources", [])
+            if not pillar_sources:
+                pillar_sources = self._fallback_sources_from_terms(documents, ["proof", "evidence"])
+            whitespace.append(
+                {
+                    "statement": "Whitespace derived from differentiated proof pillars in brand positioning.",
+                    "type": "Inferred",
+                    "sources": pillar_sources,
+                    "reasoning": "Reusing proof pillar evidence to frame opportunity gaps.",
+                }
+            )
+
+        return {
+            "competitor_contrast": competitor_signals,
+            "cultural_signals": cultural_signals,
+            "whitespace_opportunities": whitespace,
+            "macro_trends": macro_trends,
+        }
+
+    # ------------------------------------------------------------------
+    # Diagnostics helpers
+    # ------------------------------------------------------------------
+    def _compile_diagnostics(self, results: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
+        insights = self._collect_insights(results)
+        direct = sum(1 for insight in insights if insight.get("type") == "Direct")
+        inferred = sum(1 for insight in insights if insight.get("type") == "Inferred")
+        source_gaps = sum(
+            1
+            for insight in insights
+            if not insight.get("sources")
+            or not all(source.get("source") or source.get("hash") for source in insight.get("sources", []))
+        )
+
+        diagnostics = {
+            "direct_insights": direct,
+            "inferred_insights": inferred,
+            "insights_without_sources": source_gaps,
+        }
+
+        deficits: List[str] = []
+        if direct == 0:
+            deficits.append("No direct insights detected; messaging may lack evidence.")
+        if source_gaps:
+            deficits.append("Some insights missing explicit source references.")
+
+        return diagnostics, deficits
+
+    def _collect_insights(self, data: Any) -> List[Dict[str, Any]]:
+        stack: List[Any] = [data]
+        insights: List[Dict[str, Any]] = []
+        while stack:
+            item = stack.pop()
+            if isinstance(item, dict):
+                if {"type", "sources"}.issubset(item.keys()):
+                    insights.append(item)
+                stack.extend(item.values())
+            elif isinstance(item, list):
+                stack.extend(item)
+        return insights
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def _persist_results(self, run_id: Any, payload: Dict[str, Any]) -> Path:
+        run_dir = Path("/data/processed") / str(run_id)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        output_path = run_dir / "processing.json"
+        output_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        return output_path
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def _sentences_with_keyword(
+        self, documents: Sequence[Dict[str, Any]], keyword: str | None
+    ) -> List[Dict[str, str]]:
+        if not keyword:
+            return []
+        keyword = keyword.lower()
+        matches: List[Dict[str, str]] = []
+        for doc in documents:
+            for sentence in doc.get("sentences", []):
+                if keyword in sentence.lower():
+                    matches.append(self._source_entry(doc, sentence))
+        return matches
+
+    def _fallback_sources_from_terms(
+        self, documents: Sequence[Dict[str, Any]], terms: Sequence[str]
+    ) -> List[Dict[str, str]]:
+        matches: List[Dict[str, str]] = []
+        for term in terms:
+            matches.extend(self._sentences_with_keyword(documents, term))
+        if matches:
+            return matches[:3]
+        if documents:
+            doc = documents[0]
+            sentence = doc.get("sentences", [doc.get("body", "")])[0]
+            return [self._source_entry(doc, sentence)]
+        return []
+
+    def _source_entry(self, doc: Dict[str, Any], sentence: str) -> Dict[str, str]:
+        return {
+            "source": doc.get("url") or doc["id"],
+            "hash": doc["hash"],
+            "evidence": sentence.strip(),
+        }
 
 
 class AudienceStage(BaseStage):


### PR DESCRIPTION
## Summary
- orchestrate the process stage to load research corpora, derive positioning insights, and persist structured outputs with telemetry
- add helper modules that generate conversion hypotheses, ad-readiness guidance, and brand-fit scoring with labelled evidence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e217214e6c8324ac813d6525b9308e