### PR TITLE
Restore standard Codex automation pipeline

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,27 +40,7 @@ services:
       - -c
       - >-
         pip install --no-cache-dir -r requirements.txt &&
-        celery -A workers.celery_app.celery_app worker --loglevel=info --concurrency=${CELERY_WORKER_CONCURRENCY:-4} --queues=${CELERY_QUEUE_DEFAULT:-andronoma},platform_hardening
-    env_file:
-      - .env
-    depends_on:
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
-
-  hardening-worker:
-    image: python:3.11-slim
-    container_name: andronoma-hardening-worker
-    working_dir: /app
-    volumes:
-      - ./:/app
-    command:
-      - bash
-      - -c
-      - >-
-        pip install --no-cache-dir -r requirements.txt &&
-        celery -A workers.celery_app.celery_app worker --loglevel=info --concurrency=2 --queues=platform_hardening
+        celery -A workers.celery_app.celery_app worker --loglevel=info --concurrency=${CELERY_WORKER_CONCURRENCY:-4}
     env_file:
       - .env
     depends_on:

--- a/workers/celery_app.py
+++ b/workers/celery_app.py
@@ -1,14 +1,11 @@
 """Celery application configuration."""
 from __future__ import annotations
 
-import os
-
 from celery import Celery
 from celery.schedules import crontab
 from kombu import Queue
 
 from shared.config import get_settings
-from .constants import PLATFORM_HARDENING_QUEUE
 
 settings = get_settings()
 
@@ -22,30 +19,13 @@ celery_app = Celery(
 celery_app.conf.task_default_queue = "andronoma"
 celery_app.conf.task_queues = (
     Queue("andronoma", routing_key="andronoma"),
-    Queue(PLATFORM_HARDENING_QUEUE, routing_key=PLATFORM_HARDENING_QUEUE),
 )
-celery_app.conf.task_routes = {
-    "codex.*": {
-        "queue": PLATFORM_HARDENING_QUEUE,
-        "routing_key": PLATFORM_HARDENING_QUEUE,
+celery_app.conf.task_routes = {}
+
+celery_app.conf.beat_schedule = {
+    "codex-nightly": {
+        "task": "codex.standard.nightly",
+        "schedule": crontab(hour=2, minute=30),
     }
 }
-
-ENABLE_HARDENING = str(os.getenv("FEATURE_PLATFORM_HARDENING", "0")).lower() in {
-    "1",
-    "true",
-    "yes",
-    "on",
-    "y",
-}
-
-if ENABLE_HARDENING:
-    celery_app.conf.beat_schedule = {
-        "platform-hardening-nightly": {
-            "task": "codex.platform_hardening.nightly",
-            "schedule": crontab(hour=2, minute=30),
-        }
-    }
-else:
-    celery_app.conf.beat_schedule = {}
 celery_app.conf.update(task_serializer="json", accept_content=["json"], result_serializer="json")

--- a/workers/codex_tasks.py
+++ b/workers/codex_tasks.py
@@ -1,4 +1,4 @@
-"""Codex automation tasks for the platform hardening batch."""
+"""Codex automation tasks for the standard feature/refactor pipeline."""
 from __future__ import annotations
 
 import uuid
@@ -12,83 +12,79 @@ from shared.db import get_sync_session
 from shared.logs import emit_log
 from shared.models import PipelineRun, RunStatus
 from shared.pipeline import PIPELINE_ORDER
-from workers.constants import PLATFORM_HARDENING_QUEUE
 from workers.tasks import execute_pipeline_stage
 
 logger = get_task_logger(__name__)
 
 
-@shared_task(name="codex.scrape_stage_foundation")
-def scrape_stage_foundation(run_id: str) -> str:
-    """Execute the scrape stage foundation task for the provided run."""
+@shared_task(name="codex.pipeline.scrape")
+def scrape_stage(run_id: str) -> str:
+    """Execute the scrape stage for the provided run."""
 
     return execute_pipeline_stage(run_id, "scrape")
 
 
-@shared_task(name="codex.processing_stage_implementation")
-def processing_stage_implementation(run_id: str) -> str:
-    """Run the processing stage implementation task for the provided run."""
+@shared_task(name="codex.pipeline.process")
+def process_stage(run_id: str) -> str:
+    """Execute the processing stage for the provided run."""
 
     return execute_pipeline_stage(run_id, "process")
 
 
-@shared_task(name="codex.audience_generation_stage")
-def audience_generation_stage(run_id: str) -> str:
-    """Generate the platform hardening audience stage outputs."""
+@shared_task(name="codex.pipeline.audiences")
+def audiences_stage(run_id: str) -> str:
+    """Execute the audience generation stage for the provided run."""
 
     return execute_pipeline_stage(run_id, "audiences")
 
 
-@shared_task(name="codex.creative_generation_stage")
-def creative_generation_stage(run_id: str) -> str:
+@shared_task(name="codex.pipeline.creatives")
+def creatives_stage(run_id: str) -> str:
     """Execute the creative generation stage for the specified run."""
 
     return execute_pipeline_stage(run_id, "creatives")
 
 
-@shared_task(name="codex.image_rendering_stage")
-def image_rendering_stage(run_id: str) -> str:
-    """Render platform hardening images for the given run."""
+@shared_task(name="codex.pipeline.images")
+def images_stage(run_id: str) -> str:
+    """Execute the image rendering stage for the given run."""
 
     return execute_pipeline_stage(run_id, "images")
 
 
-@shared_task(name="codex.qa_stage")
+@shared_task(name="codex.pipeline.qa")
 def qa_stage(run_id: str) -> str:
-    """Execute QA stage validation for the provided run."""
+    """Execute the QA stage for the provided run."""
 
     return execute_pipeline_stage(run_id, "qa")
 
 
-@shared_task(name="codex.export_stage")
+@shared_task(name="codex.pipeline.export")
 def export_stage(run_id: str) -> str:
     """Create export artifacts for the provided run."""
 
     return execute_pipeline_stage(run_id, "export")
 
 
-PLATFORM_HARDENING_SEQUENCE: List = [
-    scrape_stage_foundation,
-    processing_stage_implementation,
-    audience_generation_stage,
-    creative_generation_stage,
-    image_rendering_stage,
+STANDARD_SEQUENCE: List = [
+    scrape_stage,
+    process_stage,
+    audiences_stage,
+    creatives_stage,
+    images_stage,
     qa_stage,
     export_stage,
 ]
 
 
 def _immutable_signatures(run_id: str) -> Iterable:
-    for task in PLATFORM_HARDENING_SEQUENCE:
-        yield task.si(run_id).set(
-            queue=PLATFORM_HARDENING_QUEUE,
-            routing_key=PLATFORM_HARDENING_QUEUE,
-        )
+    for task in STANDARD_SEQUENCE:
+        yield task.si(run_id)
 
 
-@shared_task(name="codex.platform_hardening.summary")
-def summarize_platform_hardening_run(run_id: str) -> dict:
-    """Log a completion summary once the platform hardening sequence finishes."""
+@shared_task(name="codex.standard.summary")
+def summarize_standard_run(run_id: str) -> dict:
+    """Log a completion summary once the standard pipeline sequence finishes."""
 
     run_uuid = uuid.UUID(run_id)
     stage_order = {name: index for index, name in enumerate(PIPELINE_ORDER)}
@@ -117,62 +113,60 @@ def summarize_platform_hardening_run(run_id: str) -> dict:
             "status": run.status.value,
             "stages": stage_summaries,
         }
-        emit_log(
-            session,
-            run.id,
-            "Platform hardening sequence completed",
-            metadata=payload,
-        )
+        emit_log(session, run.id, "Codex pipeline sequence completed", metadata=payload)
         return payload
 
 
-@shared_task(name="codex.platform_hardening.schedule_build")
-def schedule_platform_hardening_build(run_id: str) -> str:
-    """Kick off the full platform hardening batch for the given run."""
+@shared_task(name="codex.standard.schedule_build")
+def schedule_standard_build(run_id: str) -> str:
+    """Kick off the full feature/refactor batch for the given run."""
 
     workflow = chain(
         *_immutable_signatures(run_id),
-        summarize_platform_hardening_run.si(run_id).set(
-            queue=PLATFORM_HARDENING_QUEUE,
-            routing_key=PLATFORM_HARDENING_QUEUE,
-        ),
+        summarize_standard_run.si(run_id),
     )
     async_result = workflow.apply_async()
     logger.info(
-        "Queued platform hardening build chain", extra={"run_id": run_id, "task_id": async_result.id}
+        "Queued standard Codex build chain", extra={"run_id": run_id, "task_id": async_result.id}
     )
     return run_id
 
 
-def _is_platform_hardening(payload: dict) -> bool:
+def _is_standard_batch(payload: dict) -> bool:
     batch = str(payload.get("codex_batch") or payload.get("batch") or "").strip().lower()
-    explicit_flag = payload.get("platform_hardening")
-    return explicit_flag is True or batch == "platform_hardening"
+    explicit_hardening = payload.get("platform_hardening")
+    if explicit_hardening is True:
+        return False
+
+    if not batch:
+        return True
+
+    return batch in {"feature", "refactor"}
 
 
-@shared_task(name="codex.platform_hardening.nightly")
-def launch_platform_hardening_nightly_builds() -> int:
-    """Scan for platform hardening runs and queue background builds overnight."""
+@shared_task(name="codex.standard.nightly")
+def launch_standard_nightly_builds() -> int:
+    """Scan for pending runs and queue background builds overnight."""
 
     scheduled = 0
     with get_sync_session() as session:
         stmt = select(PipelineRun).where(PipelineRun.status == RunStatus.PENDING)
         for run in session.scalars(stmt):
             payload = dict(run.input_payload or {})
-            if not _is_platform_hardening(payload):
+            if not _is_standard_batch(payload):
                 continue
 
-            schedule_platform_hardening_build.delay(str(run.id))
+            schedule_standard_build.delay(str(run.id))
             run.status = RunStatus.RUNNING
             session.add(run)
             session.commit()
             emit_log(
                 session,
                 run.id,
-                "Queued platform hardening build via nightly scheduler",
-                metadata={"batch": "platform_hardening"},
+                "Queued Codex build via nightly scheduler",
+                metadata={"batch": payload.get("codex_batch") or payload.get("batch") or "standard"},
             )
             scheduled += 1
 
-    logger.info("Nightly platform hardening scheduler queued %s runs", scheduled)
+    logger.info("Nightly Codex scheduler queued %s runs", scheduled)
     return scheduled

--- a/workers/constants.py
+++ b/workers/constants.py
@@ -1,3 +1,0 @@
-"""Shared constants for worker configuration."""
-
-PLATFORM_HARDENING_QUEUE = "platform_hardening"


### PR DESCRIPTION
## Summary
- retarget Codex Celery tasks to run the standard feature/refactor pipeline and nightly scheduler
- simplify the Celery configuration to use the default queue and schedule the standard Codex nightly job
- update docker-compose to remove the dedicated platform hardening worker configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e25c7830a483248646d16a5e5c2710