### PR TITLE
Protect log streaming endpoint access

### DIFF
--- a/api/routes/logs.py
+++ b/api/routes/logs.py
@@ -3,18 +3,28 @@ from __future__ import annotations
 import json
 import uuid
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
 
 from shared.logs import broker
+from shared.models import PipelineRun
 
-from ..dependencies import get_current_user
+from ..dependencies import get_current_user, get_db
 
 router = APIRouter(prefix="/runs", tags=["logs"])
 
 
 @router.get("/{run_id}/logs/stream")
-async def stream_logs(run_id: uuid.UUID, user=Depends(get_current_user)):
+async def stream_logs(
+    run_id: uuid.UUID,
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+):
+    run = await session.get(PipelineRun, run_id)
+    if not run or run.owner_id != user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Run not found")
+
     async def event_generator():
         async for event in broker.stream(run_id):
             yield {


### PR DESCRIPTION
## Summary
- add ownership validation to the run log streaming endpoint before establishing the SSE stream
- ensure unauthorized users receive a not-found response when requesting logs for runs they do not own

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e265ac6cd4832484a1b93e5d30c86d