### PR TITLE
Update run status when stages change

### DIFF
--- a/api/routes/runs.py
+++ b/api/routes/runs.py
@@ -219,10 +219,14 @@ async def get_run_detail(
     session: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> RunResponse:
-    run = await session.get(PipelineRun, run_id)
+    result = await session.execute(
+        select(PipelineRun)
+        .options(selectinload(PipelineRun.stages))
+        .where(PipelineRun.id == run_id)
+    )
+    run = result.scalar_one_or_none()
     if not run or run.owner_id != current_user.id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Run not found")
-    await session.refresh(run)
     return serialize_run(run)
 
 
@@ -284,6 +288,9 @@ async def update_stage(
         stage.notes = payload.notes
         updated = True
 
+    stage_status_changed = False
+    new_stage_status: StageStatus | None = None
+
     if payload.status is not None:
         current_status = stage.status
         if payload.status != current_status:
@@ -299,6 +306,8 @@ async def update_stage(
                 stage.started_at = now
             if payload.status in {StageStatus.COMPLETED, StageStatus.FAILED, StageStatus.SKIPPED}:
                 stage.finished_at = now
+            stage_status_changed = True
+            new_stage_status = payload.status
             updated = True
 
     if payload.telemetry is not None:
@@ -317,7 +326,23 @@ async def update_stage(
         updated = True
 
     if updated:
-        run.updated_at = datetime.utcnow()
+        now = datetime.utcnow()
+        run.updated_at = now
+        if stage_status_changed:
+            await session.flush()
+            if new_stage_status == StageStatus.FAILED:
+                run.status = RunStatus.FAILED
+            else:
+                result = await session.execute(
+                    select(StageState.status).where(StageState.run_id == run.id)
+                )
+                stage_statuses = set(result.scalars().all())
+                if StageStatus.RUNNING in stage_statuses:
+                    run.status = RunStatus.RUNNING
+                elif stage_statuses and stage_statuses.issubset(
+                    {StageStatus.COMPLETED, StageStatus.SKIPPED}
+                ):
+                    run.status = RunStatus.COMPLETED
         await session.commit()
         await session.refresh(stage)
         await session.refresh(run)

--- a/api/tests/test_stage_update.py
+++ b/api/tests/test_stage_update.py
@@ -132,6 +132,43 @@ def client(session_factory: async_sessionmaker[AsyncSession]) -> TestClient:
     app.dependency_overrides.pop(get_db, None)
 
 
+def create_run_with_stage(
+    session_factory: async_sessionmaker[AsyncSession],
+    owner_id: UUID,
+    *,
+    run_status: RunStatus = RunStatus.PENDING,
+    stage_status: StageStatus = StageStatus.PENDING,
+) -> tuple[UUID, str]:
+    run_id = uuid4()
+    stage_id = uuid4()
+    stage_name = f"stage-{run_id.hex[:8]}"
+
+    async def seed() -> None:
+        async with session_factory() as session:
+            run = PipelineRun(
+                id=run_id,
+                owner_id=owner_id,
+                status=run_status,
+                input_payload={},
+                budgets={},
+                telemetry={},
+            )
+            stage = StageState(
+                id=stage_id,
+                run_id=run_id,
+                name=stage_name,
+                status=stage_status,
+                telemetry={},
+                budget_spent=0.0,
+                notes="",
+            )
+            session.add_all([run, stage])
+            await session.commit()
+
+    asyncio.run(seed())
+    return run_id, stage_name
+
+
 def test_update_stage_notes(client: TestClient, seeded_stage: SeededStage) -> None:
     owner = User(
         id=seeded_stage.owner_id,
@@ -215,6 +252,132 @@ def test_update_stage_telemetry_and_budget(
         stage_telemetry = run_state.telemetry.get(seeded_stage.stage_name, {})
         assert stage_telemetry == {"initial": True, "new_metric": 42}
         assert run_state.telemetry["other"] == {"untouched": True}
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_stage_status_running_updates_run_status(
+    client: TestClient,
+    seeded_stage: SeededStage,
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    run_id, stage_name = create_run_with_stage(
+        session_factory,
+        seeded_stage.owner_id,
+        run_status=RunStatus.PENDING,
+        stage_status=StageStatus.PENDING,
+    )
+
+    owner = User(
+        id=seeded_stage.owner_id,
+        email="owner@example.com",
+        password_hash="hash",
+    )
+    app.dependency_overrides[get_current_user] = lambda: owner
+
+    try:
+        response = client.patch(
+            f"/runs/{run_id}/stages/{stage_name}",
+            json={"status": StageStatus.RUNNING.value},
+        )
+        assert response.status_code == 200
+
+        run_response = client.get(f"/runs/{run_id}")
+        assert run_response.status_code == 200
+        run_payload = run_response.json()
+        assert run_payload["status"] == RunStatus.RUNNING.value
+
+        async def fetch_run() -> PipelineRun | None:
+            async with session_factory() as session:
+                return await session.get(PipelineRun, run_id)
+
+        db_run = asyncio.run(fetch_run())
+        assert db_run is not None
+        assert db_run.status == RunStatus.RUNNING
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_stage_status_failed_updates_run_status(
+    client: TestClient,
+    seeded_stage: SeededStage,
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    run_id, stage_name = create_run_with_stage(
+        session_factory,
+        seeded_stage.owner_id,
+        run_status=RunStatus.RUNNING,
+        stage_status=StageStatus.RUNNING,
+    )
+
+    owner = User(
+        id=seeded_stage.owner_id,
+        email="owner@example.com",
+        password_hash="hash",
+    )
+    app.dependency_overrides[get_current_user] = lambda: owner
+
+    try:
+        response = client.patch(
+            f"/runs/{run_id}/stages/{stage_name}",
+            json={"status": StageStatus.FAILED.value},
+        )
+        assert response.status_code == 200
+
+        run_response = client.get(f"/runs/{run_id}")
+        assert run_response.status_code == 200
+        run_payload = run_response.json()
+        assert run_payload["status"] == RunStatus.FAILED.value
+
+        async def fetch_run() -> PipelineRun | None:
+            async with session_factory() as session:
+                return await session.get(PipelineRun, run_id)
+
+        db_run = asyncio.run(fetch_run())
+        assert db_run is not None
+        assert db_run.status == RunStatus.FAILED
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_stage_status_completed_updates_run_status(
+    client: TestClient,
+    seeded_stage: SeededStage,
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    run_id, stage_name = create_run_with_stage(
+        session_factory,
+        seeded_stage.owner_id,
+        run_status=RunStatus.RUNNING,
+        stage_status=StageStatus.RUNNING,
+    )
+
+    owner = User(
+        id=seeded_stage.owner_id,
+        email="owner@example.com",
+        password_hash="hash",
+    )
+    app.dependency_overrides[get_current_user] = lambda: owner
+
+    try:
+        response = client.patch(
+            f"/runs/{run_id}/stages/{stage_name}",
+            json={"status": StageStatus.COMPLETED.value},
+        )
+        assert response.status_code == 200
+
+        run_response = client.get(f"/runs/{run_id}")
+        assert run_response.status_code == 200
+        run_payload = run_response.json()
+        assert run_payload["status"] == RunStatus.COMPLETED.value
+
+        async def fetch_run() -> PipelineRun | None:
+            async with session_factory() as session:
+                return await session.get(PipelineRun, run_id)
+
+        db_run = asyncio.run(fetch_run())
+        assert db_run is not None
+        assert db_run.status == RunStatus.COMPLETED
     finally:
         app.dependency_overrides.pop(get_current_user, None)
 


### PR DESCRIPTION
## Summary
- recompute and persist pipeline run status when stages transition
- preload stage data when fetching a run to support test validation
- add tests covering run status transitions and database persistence

## Testing
- pytest api/tests/test_stage_update.py

------
https://chatgpt.com/codex/tasks/task_e_68e28363fd048324bf28940d86cefe48