### PR TITLE
Surface live pipeline data across stage views

### DIFF
--- a/frontend/QA.md
+++ b/frontend/QA.md
@@ -1,0 +1,31 @@
+# Frontend QA Checklist
+
+These manual verification steps confirm that the campaign stage views render live data from the Andronoma backend APIs.
+
+1. **Authenticate and launch a run**
+   - Visit `/wizard`, register or log in, and launch a new run.
+   - Wait for the pipeline to advance to later stages (monitor from `/console`).
+
+2. **Audiences view** (`/audiences`)
+   - Click **Refresh**. Confirm stage status updates and an audience table appears with persona rows populated from the latest CSV.
+   - Verify the summary cards (segments/personas) reflect the run telemetry values and the table shows at least one row.
+
+3. **Creatives view** (`/creatives`)
+   - Click **Refresh**. Ensure concept metrics, tone highlights, and blocker coverage lists are populated from telemetry.
+   - Validate the creative table renders headlines and associated metadata sourced from the generated CSV.
+
+4. **Images view** (`/images`)
+   - Click **Refresh**. Confirm provider, rendered/requested counts, and total cost update based on the images stage telemetry.
+   - Verify that rendered image cards display concept IDs, providers, and storage paths pulled from the stage payload or asset registry.
+
+5. **QA view** (`/qa`)
+   - Click **Refresh**. Confirm the QA summary cards show totals/warnings/blockers and the checklist table lists real QA results with severity labels.
+   - If any check includes remediation guidance, ensure it appears in the table.
+
+6. **Export view** (`/export`)
+   - Click **Refresh**. Verify bundle and manifest sizes populate, download links are rendered when signed URLs or storage keys are present, and export asset metadata is listed.
+
+7. **Console regression** (`/console`)
+   - Use **Refresh** to confirm runs load without TypeScript errors after the API typing changes.
+
+If any view lacks data, confirm the corresponding pipeline stage has completed successfully and run the stage again from the console before re-testing.

--- a/frontend/src/hooks/useLatestRun.ts
+++ b/frontend/src/hooks/useLatestRun.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useAuth } from "./useAuth";
+import { AssetRecord, getRun, listRunAssets, listRuns, Run } from "../lib/api";
+
+type UseLatestRunOptions = {
+  refreshInterval?: number;
+};
+
+type UseLatestRunState = {
+  run: Run | null;
+  assets: AssetRecord[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+};
+
+function selectLatestRun(runs: Run[]): Run | null {
+  if (!runs.length) {
+    return null;
+  }
+  return runs
+    .slice()
+    .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())[0];
+}
+
+export function useLatestRun(options: UseLatestRunOptions = {}): UseLatestRunState {
+  const { token } = useAuth();
+  const [run, setRun] = useState<Run | null>(null);
+  const [assets, setAssets] = useState<AssetRecord[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const refreshInterval = options.refreshInterval ?? 0;
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const fetchLatest = useCallback(async () => {
+    if (!token) {
+      if (!mountedRef.current) return;
+      setRun(null);
+      setAssets([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const runList = await listRuns(token);
+      const latest = selectLatestRun(runList.runs);
+      if (!latest) {
+        if (!mountedRef.current) return;
+        setRun(null);
+        setAssets([]);
+        setLoading(false);
+        return;
+      }
+
+      const [runDetail, assetResponse] = await Promise.all([
+        getRun(token, latest.id),
+        listRunAssets(token, latest.id),
+      ]);
+
+      if (!mountedRef.current) return;
+      setRun(runDetail);
+      setAssets(assetResponse.assets);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError((err as Error).message);
+      setRun(null);
+      setAssets([]);
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [token]);
+
+  useEffect(() => {
+    fetchLatest();
+    if (refreshInterval > 0 && typeof window !== "undefined") {
+      const id = window.setInterval(fetchLatest, refreshInterval);
+      return () => window.clearInterval(id);
+    }
+    return undefined;
+  }, [fetchLatest, refreshInterval]);
+
+  const state = useMemo<UseLatestRunState>(
+    () => ({ run, assets, loading, error, refresh: fetchLatest }),
+    [run, assets, loading, error, fetchLatest],
+  );
+
+  return state;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,6 +2,47 @@ const API_URL = (globalThis as any).__API_URL__ as string;
 
 type RequestOptions = RequestInit & { token?: string | null };
 
+export type StageStatus = "pending" | "running" | "completed" | "failed" | "skipped";
+
+export interface StageTelemetry {
+  name: string;
+  status: StageStatus;
+  started_at: string | null;
+  finished_at: string | null;
+  telemetry: Record<string, unknown>;
+  budget_spent: number;
+  notes: string;
+}
+
+export interface Run {
+  id: string;
+  status: "pending" | "running" | "completed" | "failed" | "cancelled";
+  input_payload: Record<string, unknown> | null;
+  budgets: Record<string, number> | null;
+  telemetry: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+  stages: StageTelemetry[];
+}
+
+export interface RunListResponse {
+  runs: Run[];
+}
+
+export interface AssetRecord {
+  id: string;
+  run_id: string;
+  stage: string;
+  asset_type: string;
+  storage_key: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface AssetListResponse {
+  assets: AssetRecord[];
+}
+
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const headers: HeadersInit = {
     "Content-Type": "application/json",
@@ -43,15 +84,15 @@ export async function registerRequest(email: string, password: string) {
 }
 
 export async function listRuns(token: string) {
-  return request<{ runs: any[] }>("/runs", { token });
+  return request<RunListResponse>("/runs", { token });
 }
 
 export async function createRun(token: string, payload: any) {
-  return request("/runs", { method: "POST", token, body: JSON.stringify(payload) });
+  return request<Run>("/runs", { method: "POST", token, body: JSON.stringify(payload) });
 }
 
 export async function startRun(token: string, id: string) {
-  return request(`/runs/${id}/start`, { method: "POST", token });
+  return request<Run>(`/runs/${id}/start`, { method: "POST", token });
 }
 
 export async function getPipeline(token: string | null) {
@@ -60,4 +101,12 @@ export async function getPipeline(token: string | null) {
 
 export async function getSettings(token: string | null) {
   return request<Record<string, unknown>>("/settings", { token: token ?? undefined });
+}
+
+export async function getRun(token: string, id: string) {
+  return request<Run>(`/runs/${id}`, { token });
+}
+
+export async function listRunAssets(token: string, id: string) {
+  return request<AssetListResponse>(`/runs/${id}/assets`, { token });
 }

--- a/frontend/src/lib/dataTransforms.ts
+++ b/frontend/src/lib/dataTransforms.ts
@@ -1,0 +1,172 @@
+export type StringRecord = Record<string, string>;
+
+function coerceString(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "bigint") {
+    return String(value);
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  return JSON.stringify(value);
+}
+
+export function normalizeRecordArray(value: unknown): StringRecord[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const result: StringRecord[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      continue;
+    }
+    const entries = Object.entries(item as Record<string, unknown>);
+    if (!entries.length) {
+      continue;
+    }
+    const record: StringRecord = {};
+    for (const [key, raw] of entries) {
+      record[key] = coerceString(raw);
+    }
+    result.push(record);
+  }
+  return result;
+}
+
+function splitCsvLine(line: string): string[] {
+  const values: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (char === "\"") {
+      if (inQuotes && line[index + 1] === "\"") {
+        current += "\"";
+        index += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === "," && !inQuotes) {
+      values.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  values.push(current);
+  return values.map((value) => value.replace(/\r/g, "").trim());
+}
+
+export function parseCsvRecords(csv: string): StringRecord[] {
+  const text = csv.trim();
+  if (!text || !text.includes(",")) {
+    return [];
+  }
+  const rows: StringRecord[] = [];
+  const normalized = text.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n").filter((line) => line.length > 0);
+  if (lines.length < 2) {
+    return [];
+  }
+  const headers = splitCsvLine(lines[0]).map((header, index) => header || `column_${index + 1}`);
+  for (let i = 1; i < lines.length; i += 1) {
+    const cells = splitCsvLine(lines[i]);
+    if (cells.length === 0) {
+      continue;
+    }
+    const record: StringRecord = {};
+    headers.forEach((header, index) => {
+      record[header] = coerceString(cells[index] ?? "");
+    });
+    rows.push(record);
+  }
+  return rows;
+}
+
+function parseCsvIfLikely(value: unknown): StringRecord[] {
+  if (typeof value !== "string") {
+    return [];
+  }
+  if (!value.includes("\n") || !value.includes(",")) {
+    return [];
+  }
+  return parseCsvRecords(value);
+}
+
+export function findRecordsByColumnKeywords(root: unknown, keywords: string[]): StringRecord[] {
+  if (!root) {
+    return [];
+  }
+  const required = keywords.map((keyword) => keyword.toLowerCase());
+  const visited = new Set<unknown>();
+
+  const matchesKeywords = (record: StringRecord | undefined) => {
+    if (!record) return false;
+    const columns = Object.keys(record).map((key) => key.toLowerCase());
+    return required.every((keyword) => columns.some((column) => column.includes(keyword)));
+  };
+
+  const traverse = (value: unknown): StringRecord[] => {
+    if (value === null || value === undefined) {
+      return [];
+    }
+    if (typeof value === "string") {
+      const parsed = parseCsvIfLikely(value);
+      if (parsed.length && (!required.length || matchesKeywords(parsed[0]))) {
+        return parsed;
+      }
+      return [];
+    }
+    if (typeof value !== "object") {
+      return [];
+    }
+    if (visited.has(value)) {
+      return [];
+    }
+    visited.add(value);
+
+    if (Array.isArray(value)) {
+      const normalized = normalizeRecordArray(value);
+      if (normalized.length && (!required.length || matchesKeywords(normalized[0]))) {
+        return normalized;
+      }
+      for (const item of value) {
+        const nested = traverse(item);
+        if (nested.length) {
+          return nested;
+        }
+      }
+      return [];
+    }
+
+    const entries = Object.values(value as Record<string, unknown>);
+    for (const entry of entries) {
+      const nested = traverse(entry);
+      if (nested.length) {
+        return nested;
+      }
+    }
+    return [];
+  };
+
+  return traverse(root);
+}
+
+export function uniqueColumns(records: StringRecord[]): string[] {
+  const seen = new Set<string>();
+  const columns: string[] = [];
+  for (const record of records) {
+    for (const key of Object.keys(record)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        columns.push(key);
+      }
+    }
+  }
+  return columns;
+}

--- a/frontend/src/pages/Audiences.tsx
+++ b/frontend/src/pages/Audiences.tsx
@@ -1,30 +1,119 @@
-const sampleSegments = [
-  {
-    name: "CIO Innovators",
-    description: "Enterprise technology leaders exploring AI-driven marketing automation.",
-    size: "15k",
-  },
-  {
-    name: "Growth Marketers",
-    description: "Performance marketers testing multi-channel creative variations.",
-    size: "32k",
-  },
-];
+import { useMemo } from "react";
+
+import StageBadge from "../components/StageBadge";
+import { useLatestRun } from "../hooks/useLatestRun";
+import { findRecordsByColumnKeywords, StringRecord, uniqueColumns } from "../lib/dataTransforms";
+
+function coalesceAudienceTelemetry(runTelemetry: Record<string, unknown> | null | undefined, stageTelemetry: Record<string, unknown> | undefined) {
+  if (stageTelemetry && Object.keys(stageTelemetry).length > 0) {
+    return stageTelemetry;
+  }
+  if (runTelemetry && typeof runTelemetry === "object") {
+    const audienceData = (runTelemetry as Record<string, unknown>).audiences;
+    if (audienceData && typeof audienceData === "object") {
+      return audienceData as Record<string, unknown>;
+    }
+  }
+  return {} as Record<string, unknown>;
+}
+
+function extractAudienceRows(source: Record<string, unknown>, fallbackRoot: Record<string, unknown> | null | undefined): StringRecord[] {
+  const primary = findRecordsByColumnKeywords(source, ["audience", "name"]);
+  if (primary.length) {
+    return primary;
+  }
+  return findRecordsByColumnKeywords(fallbackRoot, ["audience", "name"]);
+}
 
 export default function Audiences() {
+  const { run, loading, error, refresh } = useLatestRun({ refreshInterval: 15000 });
+
+  const stage = run?.stages.find((item) => item.name === "audiences");
+  const stageTelemetry = useMemo<Record<string, unknown>>(
+    () => coalesceAudienceTelemetry(run?.telemetry, stage?.telemetry),
+    [run?.telemetry, stage?.telemetry],
+  );
+
+  const rows = useMemo(
+    () => extractAudienceRows(stageTelemetry, run?.telemetry as Record<string, unknown> | null | undefined),
+    [stageTelemetry, run?.telemetry],
+  );
+  const limitedRows = rows.slice(0, 12);
+  const columns = useMemo(() => uniqueColumns(limitedRows), [limitedRows]);
+
+  const segmentsValue = stageTelemetry["segments"];
+  const segments = typeof segmentsValue === "number" ? segmentsValue : undefined;
+  const personasValue = stageTelemetry["personas"];
+  const personas = typeof personasValue === "number" ? personasValue : undefined;
+  const recordsCountValue = stageTelemetry["records_count"];
+  const recordsCount = typeof recordsCountValue === "number" ? recordsCountValue : undefined;
+  const notesValue = stageTelemetry["notes"];
+  const notes = typeof notesValue === "string" ? notesValue : stage?.notes;
+
   return (
     <div className="card">
       <h2>Audience Intelligence</h2>
       <p>Review the personas and segments generated during the NLP stages.</p>
-      <div className="stage-grid">
-        {sampleSegments.map((segment) => (
-          <div key={segment.name} className="stage-card">
-            <h3>{segment.name}</h3>
-            <p>{segment.description}</p>
-            <p>Reach: {segment.size}</p>
-          </div>
-        ))}
+
+      <div style={{ display: "flex", gap: "1rem", alignItems: "center", marginBottom: "1rem" }}>
+        <button className="button secondary" onClick={refresh} disabled={loading}>
+          Refresh
+        </button>
+        {stage && <StageBadge name={stage.name} status={stage.status} />}
+        {loading && <span>Loading latest audiences…</span>}
+        {error && <span style={{ color: "var(--danger)" }}>{error}</span>}
       </div>
+
+      {!run && !loading && <p>No pipeline runs found. Launch a run from the wizard to populate this view.</p>}
+
+      {run && (
+        <>
+          <div className="stage-grid" style={{ marginBottom: "1.5rem" }}>
+            <div className="stage-card">
+              <h3>Segments</h3>
+              <p>{segments ?? recordsCount ?? rows.length || "–"}</p>
+            </div>
+            <div className="stage-card">
+              <h3>Personas</h3>
+              <p>{personas ?? "–"}</p>
+            </div>
+            <div className="stage-card">
+              <h3>Last Updated</h3>
+              <p>{stage?.finished_at ? new Date(stage.finished_at).toLocaleString() : new Date(run.updated_at).toLocaleString()}</p>
+            </div>
+          </div>
+
+          {notes && <p>{notes}</p>}
+
+          {limitedRows.length > 0 ? (
+            <div style={{ overflowX: "auto" }}>
+              <table>
+                <thead>
+                  <tr>
+                    {columns.map((column) => (
+                      <th key={column}>{column}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {limitedRows.map((row, index) => (
+                    <tr key={index}>
+                      {columns.map((column) => (
+                        <td key={column}>{row[column] ?? ""}</td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {rows.length > limitedRows.length && (
+                <p>Showing {limitedRows.length} of {rows.length} rows detected from the latest audience CSV.</p>
+              )}
+            </div>
+          ) : (
+            <p>No audience records available yet. The pipeline will populate this view once the audiences stage finishes.</p>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/Console.tsx
+++ b/frontend/src/pages/Console.tsx
@@ -3,18 +3,7 @@ import { useEffect, useState } from "react";
 import StageBadge from "../components/StageBadge";
 import { useAuth } from "../hooks/useAuth";
 import { listRuns, startRun } from "../lib/api";
-
-type Stage = {
-  name: string;
-  status: string;
-};
-
-type Run = {
-  id: string;
-  status: string;
-  created_at: string;
-  stages: Stage[];
-};
+import type { Run } from "../lib/api";
 
 export default function Console() {
   const { token } = useAuth();

--- a/frontend/src/pages/Creatives.tsx
+++ b/frontend/src/pages/Creatives.tsx
@@ -1,30 +1,182 @@
-const creatives = [
-  {
-    headline: "Accelerate go-to-market with orchestrated intelligence",
-    body: "Andronoma unifies scrape → process → audiences → creatives → images → QA → export into a single control plane.",
-    cta: "Request demo",
-  },
-  {
-    headline: "Deploy campaigns in hours, not weeks",
-    body: "Automated QA and budget enforcement keep teams confident while moving fast.",
-    cta: "See platform",
-  },
-];
+import { useMemo } from "react";
+
+import StageBadge from "../components/StageBadge";
+import { useLatestRun } from "../hooks/useLatestRun";
+import { findRecordsByColumnKeywords, StringRecord, uniqueColumns } from "../lib/dataTransforms";
+
+function coalesceCreativeTelemetry(runTelemetry: Record<string, unknown> | null | undefined, stageTelemetry: Record<string, unknown> | undefined) {
+  if (stageTelemetry && Object.keys(stageTelemetry).length > 0) {
+    return stageTelemetry;
+  }
+  if (runTelemetry && typeof runTelemetry === "object") {
+    const creativeData = (runTelemetry as Record<string, unknown>).creatives;
+    if (creativeData && typeof creativeData === "object") {
+      return creativeData as Record<string, unknown>;
+    }
+  }
+  return {} as Record<string, unknown>;
+}
+
+function extractCreativeRows(source: Record<string, unknown>, fallbackRoot: Record<string, unknown> | null | undefined): StringRecord[] {
+  const primary = findRecordsByColumnKeywords(source, ["headline"]);
+  if (primary.length) {
+    return primary;
+  }
+  return findRecordsByColumnKeywords(fallbackRoot, ["headline"]);
+}
+
+function toReadableEntries(value: unknown): { key: string; value: string }[] {
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  return Object.entries(value as Record<string, unknown>).map(([key, raw]) => {
+    if (raw === null || raw === undefined) {
+      return { key, value: "" };
+    }
+    if (typeof raw === "number") {
+      return { key, value: raw.toLocaleString() };
+    }
+    if (typeof raw === "string") {
+      return { key, value: raw };
+    }
+    if (Array.isArray(raw)) {
+      return { key, value: raw.join(", ") };
+    }
+    return { key, value: JSON.stringify(raw) };
+  });
+}
 
 export default function Creatives() {
+  const { run, loading, error, refresh } = useLatestRun({ refreshInterval: 15000 });
+
+  const stage = run?.stages.find((item) => item.name === "creatives");
+  const stageTelemetry = useMemo<Record<string, unknown>>(
+    () => coalesceCreativeTelemetry(run?.telemetry, stage?.telemetry),
+    [run?.telemetry, stage?.telemetry],
+  );
+
+  const rows = useMemo(
+    () => extractCreativeRows(stageTelemetry, run?.telemetry as Record<string, unknown> | null | undefined),
+    [stageTelemetry, run?.telemetry],
+  );
+  const limitedRows = rows.slice(0, 12);
+  const columns = useMemo(() => uniqueColumns(limitedRows), [limitedRows]);
+
+  const bucketEntries = toReadableEntries(stageTelemetry["bucket_counts"]);
+  const blockerEntries = toReadableEntries(stageTelemetry["blocker_counts"]);
+  const toneEntries = toReadableEntries(stageTelemetry["brand_tone"]);
+  const duplicateStats = stageTelemetry["duplicate_guard"];
+  const conceptsGeneratedValue = stageTelemetry["concepts_generated"];
+  const conceptsGenerated = typeof conceptsGeneratedValue === "number" ? conceptsGeneratedValue : undefined;
+  const uniqueAudienceValue = stageTelemetry["audience_unique"];
+  const uniqueAudience = typeof uniqueAudienceValue === "number" ? uniqueAudienceValue : undefined;
+
   return (
     <div className="card">
       <h2>Creative Variations</h2>
       <p>Review copy exploration coming out of the generation stage.</p>
-      <div className="stage-grid">
-        {creatives.map((creative, index) => (
-          <div key={index} className="stage-card">
-            <h3>{creative.headline}</h3>
-            <p>{creative.body}</p>
-            <span className="badge">CTA: {creative.cta}</span>
-          </div>
-        ))}
+
+      <div style={{ display: "flex", gap: "1rem", alignItems: "center", marginBottom: "1rem" }}>
+        <button className="button secondary" onClick={refresh} disabled={loading}>
+          Refresh
+        </button>
+        {stage && <StageBadge name={stage.name} status={stage.status} />}
+        {loading && <span>Loading creative output…</span>}
+        {error && <span style={{ color: "var(--danger)" }}>{error}</span>}
       </div>
+
+      {!run && !loading && <p>No pipeline runs found. Launch a run from the wizard to populate this view.</p>}
+
+      {run && (
+        <>
+          <div className="stage-grid" style={{ marginBottom: "1.5rem" }}>
+            <div className="stage-card">
+              <h3>Concepts Generated</h3>
+              <p>{conceptsGenerated !== undefined ? conceptsGenerated.toLocaleString() : rows.length || "–"}</p>
+            </div>
+            <div className="stage-card">
+              <h3>Unique Audiences</h3>
+              <p>{uniqueAudience !== undefined ? uniqueAudience.toLocaleString() : "–"}</p>
+            </div>
+            <div className="stage-card">
+              <h3>Last Updated</h3>
+              <p>{stage?.finished_at ? new Date(stage.finished_at).toLocaleString() : new Date(run.updated_at).toLocaleString()}</p>
+            </div>
+          </div>
+
+          {toneEntries.length > 0 && (
+            <div className="stage-grid" style={{ marginBottom: "1.5rem" }}>
+              {toneEntries.map((entry) => (
+                <div key={entry.key} className="stage-card">
+                  <h3>{entry.key}</h3>
+                  <p>{entry.value}</p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {bucketEntries.length > 0 && (
+            <div style={{ marginBottom: "1.5rem" }}>
+              <h3>Bucket Coverage</h3>
+              <ul>
+                {bucketEntries.map((entry) => (
+                  <li key={entry.key}>
+                    <strong>{entry.key}:</strong> {entry.value}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {blockerEntries.length > 0 && (
+            <div style={{ marginBottom: "1.5rem" }}>
+              <h3>Blocker Coverage</h3>
+              <ul>
+                {blockerEntries.map((entry) => (
+                  <li key={entry.key}>
+                    <strong>{entry.key}:</strong> {entry.value}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {duplicateStats && typeof duplicateStats === "object" && (
+            <div style={{ marginBottom: "1.5rem" }}>
+              <h3>Duplicate Guard</h3>
+              <pre style={{ whiteSpace: "pre-wrap" }}>{JSON.stringify(duplicateStats, null, 2)}</pre>
+            </div>
+          )}
+
+          {limitedRows.length > 0 ? (
+            <div style={{ overflowX: "auto" }}>
+              <table>
+                <thead>
+                  <tr>
+                    {columns.map((column) => (
+                      <th key={column}>{column}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {limitedRows.map((row, index) => (
+                    <tr key={index}>
+                      {columns.map((column) => (
+                        <td key={column}>{row[column] ?? ""}</td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {rows.length > limitedRows.length && (
+                <p>Showing {limitedRows.length} of {rows.length} creative concepts detected from the latest CSV.</p>
+              )}
+            </div>
+          ) : (
+            <p>No creative CSV rows available yet. The pipeline will populate this view after the creatives stage completes.</p>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/Export.tsx
+++ b/frontend/src/pages/Export.tsx
@@ -1,39 +1,220 @@
-const exports = [
-  {
-    name: "Creative package",
-    status: "ready",
-    link: "s3://andronoma/campaign.zip",
-  },
-  {
-    name: "Audience CSV",
-    status: "ready",
-    link: "s3://andronoma/audiences.csv",
-  },
-];
+import { useMemo } from "react";
+
+import StageBadge from "../components/StageBadge";
+import { useLatestRun } from "../hooks/useLatestRun";
+import { AssetRecord } from "../lib/api";
+
+type ExportLink = {
+  label: string;
+  url: string;
+};
+
+function formatBytes(bytes: number | undefined): string {
+  if (bytes === undefined || Number.isNaN(bytes)) {
+    return "–";
+  }
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const index = Math.floor(Math.log(bytes) / Math.log(1024));
+  const value = bytes / 1024 ** index;
+  return `${value.toFixed(1)} ${units[index]}`;
+}
+
+function linkFromTelemetry(entry: Record<string, unknown> | undefined, fallbackLabel: string): ExportLink | null {
+  if (!entry) return null;
+  const signedUrl = typeof entry["signed_url"] === "string" ? entry["signed_url"] : null;
+  const storageKey = typeof entry["storage_key"] === "string" ? entry["storage_key"] : null;
+  const label = typeof entry["label"] === "string" ? entry["label"] : fallbackLabel;
+  const url = signedUrl || storageKey;
+  if (!url) return null;
+  return { label, url };
+}
+
+function buildExportLinks(telemetry: Record<string, unknown>): ExportLink[] {
+  const links: ExportLink[] = [];
+  const bundle = telemetry["bundle"] && typeof telemetry["bundle"] === "object" ? (telemetry["bundle"] as Record<string, unknown>) : undefined;
+  const manifest = telemetry["manifest"] && typeof telemetry["manifest"] === "object" ? (telemetry["manifest"] as Record<string, unknown>) : undefined;
+  const optionalExports = telemetry["optional_exports"] && typeof telemetry["optional_exports"] === "object" ? (telemetry["optional_exports"] as Record<string, unknown>) : undefined;
+
+  const bundleLink = linkFromTelemetry(bundle, "Export bundle");
+  if (bundleLink) {
+    links.push(bundleLink);
+  }
+
+  const manifestLink = linkFromTelemetry(manifest, "Manifest JSON");
+  if (manifestLink) {
+    links.push(manifestLink);
+  }
+
+  if (optionalExports) {
+    const google = optionalExports["google_sheets"];
+    if (google && typeof google === "object" && typeof (google as Record<string, unknown>)["workbook_url"] === "string") {
+      links.push({ label: "Google Sheets Workbook", url: (google as Record<string, unknown>)["workbook_url"] as string });
+    }
+    const meta = optionalExports["meta"];
+    if (meta && typeof meta === "object" && typeof (meta as Record<string, unknown>)["download_url"] === "string") {
+      links.push({ label: "Meta Ads CSV", url: (meta as Record<string, unknown>)["download_url"] as string });
+    }
+  }
+
+  return links;
+}
+
+function exportAssetsFromRecords(records: AssetRecord[]): AssetRecord[] {
+  return records.filter((asset) => asset.stage === "export");
+}
 
 export default function ExportPage() {
+  const { run, assets, loading, error, refresh } = useLatestRun({ refreshInterval: 15000 });
+
+  const stage = run?.stages.find((item) => item.name === "export");
+  const telemetry = useMemo(() => {
+    if (stage?.telemetry && Object.keys(stage.telemetry).length > 0) {
+      return stage.telemetry as Record<string, unknown>;
+    }
+    if (run?.telemetry && typeof run.telemetry === "object") {
+      const exportTelemetry = (run.telemetry as Record<string, unknown>).export;
+      if (exportTelemetry && typeof exportTelemetry === "object") {
+        return exportTelemetry as Record<string, unknown>;
+      }
+    }
+    return {} as Record<string, unknown>;
+  }, [stage?.telemetry, run?.telemetry]);
+
+  const exportLinks = useMemo(() => buildExportLinks(telemetry), [telemetry]);
+  const exportAssets = useMemo(() => exportAssetsFromRecords(assets), [assets]);
+
+  const bundleInfo = telemetry["bundle"] && typeof telemetry["bundle"] === "object" ? (telemetry["bundle"] as Record<string, unknown>) : undefined;
+  const manifestInfo = telemetry["manifest"] && typeof telemetry["manifest"] === "object" ? (telemetry["manifest"] as Record<string, unknown>) : undefined;
+  const assetCounts = telemetry["asset_counts"] && typeof telemetry["asset_counts"] === "object" ? (telemetry["asset_counts"] as Record<string, unknown>) : {};
+  const readmeEntries = telemetry["readme_map"] && Array.isArray(telemetry["readme_map"]) ? (telemetry["readme_map"] as Array<Record<string, unknown>>) : [];
+
+  const bundleSizeValue = bundleInfo ? bundleInfo["size_bytes"] : undefined;
+  const bundleSize = typeof bundleSizeValue === "number" ? bundleSizeValue : undefined;
+  const manifestSizeValue = manifestInfo ? manifestInfo["size_bytes"] : undefined;
+  const manifestSize = typeof manifestSizeValue === "number" ? manifestSizeValue : undefined;
+
   return (
     <div className="card">
       <h2>Export Center</h2>
       <p>Download campaign artifacts once QA approves the run.</p>
-      <table>
-        <thead>
-          <tr>
-            <th>Asset</th>
-            <th>Status</th>
-            <th>Location</th>
-          </tr>
-        </thead>
-        <tbody>
-          {exports.map((item) => (
-            <tr key={item.name}>
-              <td>{item.name}</td>
-              <td>{item.status}</td>
-              <td>{item.link}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+
+      <div style={{ display: "flex", gap: "1rem", alignItems: "center", marginBottom: "1rem" }}>
+        <button className="button secondary" onClick={refresh} disabled={loading}>
+          Refresh
+        </button>
+        {stage && <StageBadge name={stage.name} status={stage.status} />}
+        {loading && <span>Loading export metadata…</span>}
+        {error && <span style={{ color: "var(--danger)" }}>{error}</span>}
+      </div>
+
+      {!run && !loading && <p>No pipeline runs found. Launch a run from the wizard to populate this view.</p>}
+
+      {run && (
+        <>
+          <div className="stage-grid" style={{ marginBottom: "1.5rem" }}>
+            <div className="stage-card">
+              <h3>Bundle Size</h3>
+              <p>{formatBytes(bundleSize)}</p>
+            </div>
+            <div className="stage-card">
+              <h3>Manifest Size</h3>
+              <p>{formatBytes(manifestSize)}</p>
+            </div>
+            <div className="stage-card">
+              <h3>Assets Included</h3>
+              <p>
+                {Object.values(assetCounts).length > 0
+                  ? Object.entries(assetCounts)
+                      .map(([key, value]) => {
+                        if (typeof value === "number") return `${key}: ${value}`;
+                        if (typeof value === "string") return `${key}: ${value}`;
+                        return `${key}: ${JSON.stringify(value)}`;
+                      })
+                      .join(", ")
+                  : "–"}
+              </p>
+            </div>
+            <div className="stage-card">
+              <h3>Last Updated</h3>
+              <p>{stage?.finished_at ? new Date(stage.finished_at).toLocaleString() : new Date(run.updated_at).toLocaleString()}</p>
+            </div>
+          </div>
+
+          {exportLinks.length > 0 && (
+            <div style={{ marginBottom: "1.5rem" }}>
+              <h3>Download Links</h3>
+              <ul>
+                {exportLinks.map((link) => (
+                  <li key={link.url}>
+                    <a href={link.url} target="_blank" rel="noreferrer">
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {readmeEntries.length > 0 && (
+            <div style={{ marginBottom: "1.5rem" }}>
+              <h3>Bundle Manifest</h3>
+              <ul>
+                {readmeEntries.map((entry, index) => {
+                  const title = typeof entry["title"] === "string" ? entry["title"] : `Entry ${index + 1}`;
+                  const description = typeof entry["description"] === "string" ? entry["description"] : "";
+                  const path = typeof entry["path"] === "string" ? entry["path"] : undefined;
+                  const url = typeof entry["url"] === "string" ? entry["url"] : undefined;
+                  return (
+                    <li key={`${title}-${index}`}>
+                      <strong>{title}</strong>
+                      {path && <span> — {path}</span>}
+                      {url && (
+                        <span>
+                          {" "}
+                          (<a href={url} target="_blank" rel="noreferrer">external</a>)
+                        </span>
+                      )}
+                      {description && <div>{description}</div>}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          <div style={{ overflowX: "auto" }}>
+            <table>
+              <thead>
+                <tr>
+                  <th>Asset</th>
+                  <th>Storage Key</th>
+                  <th>Metadata</th>
+                  <th>Created</th>
+                </tr>
+              </thead>
+              <tbody>
+                {exportAssets.length > 0 ? (
+                  exportAssets.map((asset) => (
+                    <tr key={asset.id}>
+                      <td>{asset.asset_type}</td>
+                      <td style={{ wordBreak: "break-all" }}>{asset.storage_key}</td>
+                      <td>
+                        <pre style={{ whiteSpace: "pre-wrap" }}>{JSON.stringify(asset.metadata, null, 2)}</pre>
+                      </td>
+                      <td>{new Date(asset.created_at).toLocaleString()}</td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td colSpan={4}>No export assets recorded yet.</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/Images.tsx
+++ b/frontend/src/pages/Images.tsx
@@ -1,28 +1,133 @@
-const gallery = [
-  {
-    title: "Futuristic workspace",
-    description: "Hero image exploring collaboration between humans and AI systems.",
-  },
-  {
-    title: "Data activation",
-    description: "Concept art depicting data flowing into actionable insights.",
-  },
-];
+import { useMemo } from "react";
+
+import StageBadge from "../components/StageBadge";
+import { useLatestRun } from "../hooks/useLatestRun";
+import { AssetRecord } from "../lib/api";
+
+type ImageCard = {
+  concept: string;
+  path: string;
+  provider?: string;
+  cost?: string;
+  contrast?: string;
+};
+
+function toImageCards(telemetryAssets: unknown, assetRecords: AssetRecord[]): ImageCard[] {
+  const cards: ImageCard[] = [];
+  if (Array.isArray(telemetryAssets)) {
+    for (const item of telemetryAssets) {
+      if (!item || typeof item !== "object") continue;
+      const record = item as Record<string, unknown>;
+      const conceptId = typeof record["concept_id"] === "string" ? record["concept_id"] : undefined;
+      const path = typeof record["path"] === "string" ? record["path"] : undefined;
+      if (!conceptId || !path) continue;
+      const provider = typeof record["provider"] === "string" ? record["provider"] : undefined;
+      const costValue = record["cost"];
+      const cost = typeof costValue === "number" ? `$${costValue.toFixed(2)}` : undefined;
+      const contrast = typeof record["contrast_ratio"] === "number" ? record["contrast_ratio"].toFixed(2) : undefined;
+      cards.push({ concept: conceptId, path, provider, cost, contrast });
+    }
+  }
+
+  const recorded = assetRecords
+    .filter((asset) => asset.stage === "images")
+    .map((asset) => {
+      const metadata = asset.metadata || {};
+      const concept = typeof metadata["concept_id"] === "string" ? metadata["concept_id"] : asset.asset_type;
+      const provider = typeof metadata["render"] === "object" && metadata["render"] && typeof (metadata["render"] as Record<string, unknown>)["mode"] === "string"
+        ? ((metadata["render"] as Record<string, unknown>)["mode"] as string)
+        : undefined;
+      const costValue = typeof metadata["cost"] === "number" ? metadata["cost"] : undefined;
+      const contrastValue =
+        typeof metadata["overlay"] === "object" && metadata["overlay"] && typeof (metadata["overlay"] as Record<string, unknown>)["contrast"] === "object"
+          ? ((metadata["overlay"] as Record<string, unknown>)["contrast"] as Record<string, unknown>)["ratio"]
+          : undefined;
+      const contrast = typeof contrastValue === "number" ? contrastValue.toFixed(2) : undefined;
+      return {
+        concept,
+        path: asset.storage_key,
+        provider,
+        cost: costValue !== undefined ? `$${costValue.toFixed(2)}` : undefined,
+        contrast,
+      };
+    });
+
+  const combined = [...cards];
+  for (const record of recorded) {
+    if (!combined.some((card) => card.path === record.path)) {
+      combined.push(record);
+    }
+  }
+  return combined;
+}
 
 export default function Images() {
+  const { run, assets, loading, error, refresh } = useLatestRun({ refreshInterval: 15000 });
+
+  const stage = run?.stages.find((item) => item.name === "images");
+  const stageTelemetry = (stage?.telemetry && typeof stage.telemetry === "object" ? stage.telemetry : {}) as Record<string, unknown>;
+
+  const cards = useMemo(() => toImageCards(stageTelemetry["assets"], assets), [stageTelemetry, assets]);
+
+  const provider = typeof stageTelemetry["provider"] === "string" ? (stageTelemetry["provider"] as string) : undefined;
+  const renderedCount = typeof stageTelemetry["rendered"] === "number" ? (stageTelemetry["rendered"] as number) : cards.length;
+  const requestedCount = typeof stageTelemetry["requested"] === "number" ? (stageTelemetry["requested"] as number) : undefined;
+  const costValue = typeof stageTelemetry["cost"] === "number" ? (stageTelemetry["cost"] as number) : undefined;
+
   return (
     <div className="card">
       <h2>Image Generation</h2>
       <p>Curated visual options ready for QA review.</p>
-      <div className="stage-grid">
-        {gallery.map((image) => (
-          <div key={image.title} className="stage-card">
-            <h3>{image.title}</h3>
-            <p>{image.description}</p>
-            <span className="badge">Variation</span>
-          </div>
-        ))}
+
+      <div style={{ display: "flex", gap: "1rem", alignItems: "center", marginBottom: "1rem" }}>
+        <button className="button secondary" onClick={refresh} disabled={loading}>
+          Refresh
+        </button>
+        {stage && <StageBadge name={stage.name} status={stage.status} />}
+        {loading && <span>Loading image telemetry…</span>}
+        {error && <span style={{ color: "var(--danger)" }}>{error}</span>}
       </div>
+
+      {!run && !loading && <p>No pipeline runs found. Launch a run from the wizard to populate this view.</p>}
+
+      {run && (
+        <>
+          <div className="stage-grid" style={{ marginBottom: "1.5rem" }}>
+            <div className="stage-card">
+              <h3>Provider</h3>
+              <p>{provider ?? "Unknown"}</p>
+            </div>
+            <div className="stage-card">
+              <h3>Rendered</h3>
+              <p>{renderedCount}</p>
+            </div>
+            <div className="stage-card">
+              <h3>Requested</h3>
+              <p>{requestedCount ?? "–"}</p>
+            </div>
+            <div className="stage-card">
+              <h3>Total Cost</h3>
+              <p>{costValue !== undefined ? `$${costValue.toFixed(2)}` : "–"}</p>
+            </div>
+          </div>
+
+          {cards.length > 0 ? (
+            <div className="stage-grid">
+              {cards.map((card) => (
+                <div key={`${card.concept}-${card.path}`} className="stage-card">
+                  <h3>{card.concept}</h3>
+                  <p>{card.provider ? `Provider: ${card.provider}` : ""}</p>
+                  {card.cost && <p>Cost: {card.cost}</p>}
+                  {card.contrast && <p>Contrast ratio: {card.contrast}</p>}
+                  <p style={{ wordBreak: "break-all" }}>{card.path}</p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p>No rendered images detected yet. They will appear here when the images stage completes.</p>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/QA.tsx
+++ b/frontend/src/pages/QA.tsx
@@ -1,44 +1,160 @@
-const checks = [
-  {
-    name: "Brand safety",
-    result: "passed",
-    notes: "Copy references approved messaging pillars only.",
-  },
-  {
-    name: "Budget adherence",
-    result: "passed",
-    notes: "Projected spend within configured thresholds.",
-  },
-  {
-    name: "Accessibility",
-    result: "attention",
-    notes: "Image alt text requires manual review.",
-  },
-];
+import { useMemo } from "react";
+
+import StageBadge from "../components/StageBadge";
+import { useLatestRun } from "../hooks/useLatestRun";
+
+type QACheck = {
+  name: string;
+  severity: string;
+  message: string;
+  remediation?: string;
+  details?: unknown;
+};
+
+const severityLabels: Record<string, string> = {
+  pass: "Pass",
+  warning: "Warning",
+  blocker: "Blocker",
+};
+
+function normalizeChecks(value: unknown): QACheck[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item) => {
+      if (!item || typeof item !== "object") return null;
+      const record = item as Record<string, unknown>;
+      const name = typeof record["name"] === "string" ? record["name"] : null;
+      if (!name) return null;
+      const severity = typeof record["severity"] === "string" ? record["severity"] : "unknown";
+      const message = typeof record["message"] === "string" ? record["message"] : "";
+      const remediation = typeof record["remediation"] === "string" ? record["remediation"] : undefined;
+      const details = record["details"];
+      return { name, severity, message, remediation, details };
+    })
+    .filter((item): item is QACheck => Boolean(item));
+}
+
+function formatDetails(details: unknown): string | null {
+  if (!details || typeof details !== "object") {
+    return null;
+  }
+  try {
+    return JSON.stringify(details, null, 2);
+  } catch (error) {
+    return null;
+  }
+}
 
 export default function QA() {
+  const { run, loading, error, refresh } = useLatestRun({ refreshInterval: 15000 });
+
+  const stage = run?.stages.find((item) => item.name === "qa");
+  const telemetry = useMemo(() => {
+    if (stage?.telemetry && Object.keys(stage.telemetry).length > 0) {
+      return stage.telemetry as Record<string, unknown>;
+    }
+    if (run?.telemetry && typeof run.telemetry === "object") {
+      const qaTelemetry = (run.telemetry as Record<string, unknown>).qa;
+      if (qaTelemetry && typeof qaTelemetry === "object") {
+        return qaTelemetry as Record<string, unknown>;
+      }
+    }
+    return {} as Record<string, unknown>;
+  }, [stage?.telemetry, run?.telemetry]);
+
+  const checks = useMemo(() => normalizeChecks(telemetry["checks"]), [telemetry]);
+  const counts = telemetry["counts"] && typeof telemetry["counts"] === "object" ? (telemetry["counts"] as Record<string, unknown>) : {};
+  const failureBreakdown = telemetry["failure_breakdown"] && typeof telemetry["failure_breakdown"] === "object" ? (telemetry["failure_breakdown"] as Record<string, unknown>) : {};
+  const notes = typeof telemetry["notes"] === "string" ? (telemetry["notes"] as string) : stage?.notes;
+
   return (
     <div className="card">
       <h2>Quality Automation</h2>
       <p>Every run is gated by the QA checklist before export.</p>
-      <table>
-        <thead>
-          <tr>
-            <th>Check</th>
-            <th>Result</th>
-            <th>Notes</th>
-          </tr>
-        </thead>
-        <tbody>
-          {checks.map((check) => (
-            <tr key={check.name}>
-              <td>{check.name}</td>
-              <td>{check.result}</td>
-              <td>{check.notes}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+
+      <div style={{ display: "flex", gap: "1rem", alignItems: "center", marginBottom: "1rem" }}>
+        <button className="button secondary" onClick={refresh} disabled={loading}>
+          Refresh
+        </button>
+        {stage && <StageBadge name={stage.name} status={stage.status} />}
+        {loading && <span>Loading QA report…</span>}
+        {error && <span style={{ color: "var(--danger)" }}>{error}</span>}
+      </div>
+
+      {!run && !loading && <p>No pipeline runs found. Launch a run from the wizard to populate this view.</p>}
+
+      {run && (
+        <>
+          <div className="stage-grid" style={{ marginBottom: "1.5rem" }}>
+            <div className="stage-card">
+              <h3>Total Checks</h3>
+              <p>{typeof counts["total"] === "number" ? (counts["total"] as number) : checks.length}</p>
+            </div>
+            <div className="stage-card">
+              <h3>Warnings</h3>
+              <p>{typeof counts["warnings"] === "number" ? (counts["warnings"] as number) : "–"}</p>
+            </div>
+            <div className="stage-card">
+              <h3>Blockers</h3>
+              <p>{typeof counts["blockers"] === "number" ? (counts["blockers"] as number) : "–"}</p>
+            </div>
+            <div className="stage-card">
+              <h3>Last Updated</h3>
+              <p>{stage?.finished_at ? new Date(stage.finished_at).toLocaleString() : new Date(run.updated_at).toLocaleString()}</p>
+            </div>
+          </div>
+
+          {Object.keys(failureBreakdown).length > 0 && (
+            <div style={{ marginBottom: "1.5rem" }}>
+              <h3>Failure Breakdown</h3>
+              <ul>
+                {Object.entries(failureBreakdown).map(([key, value]) => (
+                  <li key={key}>
+                    <strong>{key}:</strong> {typeof value === "number" ? value : JSON.stringify(value)}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {notes && <p>{notes}</p>}
+
+          {checks.length > 0 ? (
+            <div style={{ overflowX: "auto" }}>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Check</th>
+                    <th>Severity</th>
+                    <th>Message</th>
+                    <th>Remediation</th>
+                    <th>Details</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {checks.map((check) => {
+                    const severityLabel = severityLabels[check.severity] ?? check.severity;
+                    const detailText = formatDetails(check.details);
+                    return (
+                      <tr key={check.name}>
+                        <td>{check.name}</td>
+                        <td>{severityLabel}</td>
+                        <td>{check.message}</td>
+                        <td>{check.remediation || ""}</td>
+                        <td>{detailText ? <pre style={{ whiteSpace: "pre-wrap" }}>{detailText}</pre> : ""}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p>No QA checks have been recorded yet for the latest run.</p>
+          )}
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add typed API clients for run details, stage telemetry, and asset listings
- introduce a reusable hook plus telemetry parsers for fetching the latest run output
- replace placeholder stage UIs with live data rendering and add QA checklist documentation

## Testing
- npm install *(fails: registry does not include @types/clsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e337f1781c8324aa16918808eb8cb2