### PR TITLE
Normalize timestamps to timezone-aware UTC

### DIFF
--- a/api/tests/test_assets_endpoint.py
+++ b/api/tests/test_assets_endpoint.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import AsyncIterator
 from uuid import UUID, uuid4
@@ -79,7 +79,7 @@ def seeded_assets(session_factory: async_sessionmaker[AsyncSession]) -> SeededAs
     owner_id = uuid4()
     run_id = uuid4()
     asset_ids = [uuid4(), uuid4(), uuid4()]
-    created = datetime.utcnow()
+    created = datetime.now(UTC)
 
     async def seed() -> None:
         async with session_factory() as session:

--- a/api/tests/test_logs_history.py
+++ b/api/tests/test_logs_history.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import AsyncIterator
 from uuid import UUID, uuid4
@@ -79,7 +79,7 @@ def seeded_data(session_factory: async_sessionmaker[AsyncSession]) -> SeededRun:
     owner_id = uuid4()
     run_id = uuid4()
     log_ids = [uuid4(), uuid4(), uuid4()]
-    created = datetime.utcnow()
+    created = datetime.now(UTC)
 
     async def seed() -> None:
         async with session_factory() as session:

--- a/api/tests/test_run_cancel.py
+++ b/api/tests/test_run_cancel.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import AsyncIterator
 from uuid import UUID, uuid4
@@ -102,7 +102,7 @@ async def seed_run(
             user = User(id=owner_id, email=email, password_hash="hash")
             session.add(user)
 
-        now = datetime.utcnow() - timedelta(hours=1)
+        now = datetime.now(UTC) - timedelta(hours=1)
         run = PipelineRun(
             id=run_id,
             owner_id=owner_id,
@@ -139,7 +139,7 @@ def test_cancel_run_success(
     run_id = uuid4()
     owner_email = f"{owner_id}@example.com"
 
-    stage_started = datetime.utcnow() - timedelta(minutes=30)
+    stage_started = datetime.now(UTC) - timedelta(minutes=30)
 
     asyncio.run(
         seed_run(
@@ -150,7 +150,7 @@ def test_cancel_run_success(
             stages=[
                 ("scrape", StageStatus.PENDING, None, None),
                 ("process", StageStatus.RUNNING, stage_started, None),
-                ("qa", StageStatus.COMPLETED, stage_started, datetime.utcnow()),
+                ("qa", StageStatus.COMPLETED, stage_started, datetime.now(UTC)),
             ],
             owner_email=owner_email,
         )
@@ -236,7 +236,14 @@ def test_cancel_run_invalid_status(
             owner_id=owner_id,
             run_id=run_id,
             status=RunStatus.COMPLETED,
-            stages=[("scrape", StageStatus.COMPLETED, datetime.utcnow(), datetime.utcnow())],
+            stages=[
+                (
+                    "scrape",
+                    StageStatus.COMPLETED,
+                    datetime.now(UTC),
+                    datetime.now(UTC),
+                )
+            ],
             owner_email=owner_email,
         )
     )

--- a/nlp/pipeline.py
+++ b/nlp/pipeline.py
@@ -119,7 +119,7 @@ class ProcessStage(BaseStage):
             motivation_map,
         )
 
-        generated_at = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
+        generated_at = dt.datetime.now(dt.UTC)
         result_bundle = {
             "run_id": str(run.id),
             "generated_at": generated_at.isoformat(),

--- a/scrape/crawler.py
+++ b/scrape/crawler.py
@@ -51,8 +51,10 @@ class CrawlerResponse:
         timestamp = (
             dt.datetime.fromisoformat(str(fetched_at))
             if isinstance(fetched_at, str)
-            else dt.datetime.utcnow()
+            else dt.datetime.now(dt.UTC)
         )
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=dt.UTC)
         return cls(
             url=str(payload.get("url")),
             status=int(payload.get("status", 0)),
@@ -217,7 +219,7 @@ class PlaywrightCrawler:
             status=status,
             body=body,
             headers=headers,
-            fetched_at=dt.datetime.utcnow(),
+            fetched_at=dt.datetime.now(dt.UTC),
             latency=0.0,
             from_cache=False,
         )
@@ -234,7 +236,7 @@ class PlaywrightCrawler:
             status=resp.status_code,
             body=resp.text,
             headers=dict(resp.headers),
-            fetched_at=dt.datetime.utcnow(),
+            fetched_at=dt.datetime.now(dt.UTC),
             latency=0.0,
             from_cache=False,
         )

--- a/scrape/service.py
+++ b/scrape/service.py
@@ -475,7 +475,7 @@ class ScrapeStage(BaseStage):
     ) -> str:
         manifest = {
             "run_id": str(run_id),
-            "generated_at": dt.datetime.utcnow().isoformat(),
+            "generated_at": dt.datetime.now(dt.UTC).isoformat(),
             "datasets": entries,
             "coverage": coverage,
             "crawler_metrics": metrics,

--- a/shared/stages/base.py
+++ b/shared/stages/base.py
@@ -50,7 +50,7 @@ class BaseStage(abc.ABC):
             state = StageState(id=uuid.uuid4(), run_id=self.context.run.id, name=self.name)
             session.add(state)
             self.context.run.stages.append(state)
-        now = dt.datetime.utcnow()
+        now = dt.datetime.now(dt.UTC)
         if status == StageStatus.RUNNING:
             state.started_at = now
         if status in {StageStatus.COMPLETED, StageStatus.FAILED, StageStatus.SKIPPED}:


### PR DESCRIPTION
## Summary
- ensure database models and run serialization always emit timezone-aware UTC datetimes
- replace deprecated datetime.utcnow() usage across services, scraping utilities, and tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e367cfba9c83249112ec8bedd652af